### PR TITLE
added python-ci-versioneer

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,8 @@
 # Python package to PiPy. This makes use of Twine and is triggered when a push
 # to the main branch occures. For more information see:
 # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# and for details on the Autobump version section see:
+# https://github.com/grst/python-ci-versioneer
 
 name: Upload Python Package
 
@@ -20,10 +22,24 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
+    - name: Autobump version
+      run: |
+        # from refs/tags/v1.2.3 get 1.2.3
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        PLACEHOLDER='version="develop"'
+        VERSION_FILE='setup.py'
+        # Grep checks that the placeholder is in the file. If grep doesn't find
+        # the placeholder then it exits with exit code 1 and github actions fails.
+        grep "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s/$PLACEHOLDER/version=\"${VERSION}\"/g" "$VERSION_FILE"
+      shell: bash
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="paramak",
-    version="0.2.8",
+    version="develop",
     author="The Paramak Development Team",
     author_email="mail@jshimwell.com",
     description="Create 3D fusion reactor CAD models based on input parameters",


### PR DESCRIPTION
## Proposed changes

This change to the python publish CI automates the version tagging of the pypi package as proposed by @RemDelaporteMathurin 

It makes use of the example [here ](https://github.com/grst/python-ci-versioneer/blob/master/LICENSE) with small adaptations discussed [here](https://github.com/openmc-data-storage/openmc_data_to_json/issues/22)

I've tested the yml file with a mini release and it found the version number correctly https://github.com/fusion-energy/paramak/actions/runs/1044561332

This should save use a decent amount of time each release and remove the need for those "bump version commits" moving forwards

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
