### PR TITLE
added 3d shape to docs for PoloidalSegmenter

### DIFF
--- a/docs/source/paramak.parametric_components.rst
+++ b/docs/source/paramak.parametric_components.rst
@@ -503,6 +503,19 @@ PoloidalFieldCoilCaseSetFC()
 PoloidalSegmenter()
 ^^^^^^^^^^^^^^^^^^^
 
+.. cadquery::
+   :select: cadquery_object
+   :gridsize: 0
+
+   import paramak
+   my_component = paramak.PoloidalSegments(
+      shape_to_segment=None,
+      center_point=(450, 0),
+      number_of_segments=10,
+   )
+
+   cadquery_object = my_component.solid
+
 .. image:: https://user-images.githubusercontent.com/8583900/93811079-84da5480-fc47-11ea-9c6c-7fd132f6d72d.png
     :width: 605px
     :align: center

--- a/docs/source/paramak.parametric_components.rst
+++ b/docs/source/paramak.parametric_components.rst
@@ -512,6 +512,7 @@ PoloidalSegmenter()
       shape_to_segment=None,
       center_point=(450, 0),
       number_of_segments=10,
+      rotation_angle=180,
    )
 
    cadquery_object = my_component.solid


### PR DESCRIPTION
## Proposed changes

This adds another 3d interactive shape to the docs. The example for this particular shape came from the examples folder [here](https://github.com/fusion-energy/paramak/blob/main/examples/example_parametric_components/make_firstwall_for_neutron_wall_loading.ipynb).

This is one of the many PRs that will be needed to close issue #30

I tested this by building the docs locally with sphinx. The 3d model didn't appear locally but[ it does on the automated readTheDocs build](https://paramak--31.org.readthedocs.build/en/31/paramak.parametric_components.html#poloidalsegmenter) that gets trigger for every PR

The status of the read the docs builds can be found for each PR, here is the one for this PR
[readTheDocs build for this PR](https://readthedocs.org/projects/paramak/builds/14271782/)

```
# local testing with sphinx completed error free
cd docs
bash build-docs.sh
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
