### PR TITLE
Adding center point to center column cylinder

### DIFF
--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -57,10 +57,6 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             raise TypeError(
                 "CenterColumnShieldBlock.center_height should be a float or int. Not a {}".format(
                     type(value)))
-        if value is None:
-            raise ValueError(
-                "center_height of the CenterColumnShieldBlock cannot be None"
-            )
         self._center_height = value
 
     @property

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -9,6 +9,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         height: height of the center column shield.
         inner_radius: the inner radius of the center column shield.
         outer_radius: the outer radius of the center column shield.
+        center_height: the vertical height of the center of the component.
         stp_filename: Defaults to "CenterColumnShieldCylinder.stp".
         stl_filename: Defaults to "CenterColumnShieldCylinder.stl".
         material_tag: Defaults to "center_column_shield_mat".

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -1,4 +1,3 @@
-
 from typing import Optional, Tuple
 from paramak import RotateStraightShape
 
@@ -20,11 +19,16 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         height: float,
         inner_radius: float,
         outer_radius: float,
+        center_height: float = 0,
+        name="CenterColumnShieldCylinder",
         stp_filename: Optional[str] = "CenterColumnShieldCylinder.stp",
         stl_filename: Optional[str] = "CenterColumnShieldCylinder.stl",
         material_tag: Optional[str] = "center_column_shield_mat",
-        color: Optional[Tuple[float, float, float,
-                              Optional[float]]] = (0., 0.333, 0.),
+        color: Optional[Tuple[float, float, float, Optional[float]]] = (
+            0.0,
+            0.333,
+            0.0,
+        ),
         **kwargs
     ) -> None:
 
@@ -33,12 +37,32 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             stp_filename=stp_filename,
             stl_filename=stl_filename,
             color=color,
+            name=name,
             **kwargs
         )
 
         self.height = height
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
+        self.center_height = center_height
+
+    @property
+    def center_height(self):
+        return self._center_height
+
+    @center_height.setter
+    def center_height(self, value):
+        if not isinstance(value, (int, float)):
+            raise TypeError(
+                "CenterColumnShieldBlock.center_height should be a float or int. Not a {}".format(
+                    type(value)
+                )
+            )
+        if value is None:
+            raise ValueError(
+                "center_height of the CenterColumnShieldBlock cannot be None"
+            )
+        self._center_height = value
 
     @property
     def height(self):
@@ -47,8 +71,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
     @height.setter
     def height(self, value):
         if value is None:
-            raise ValueError(
-                "height of the CenterColumnShieldBlock cannot be None")
+            raise ValueError("height of the CenterColumnShieldBlock cannot be None")
         self._height = value
 
     @property
@@ -61,7 +84,9 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             if value >= self.outer_radius:
                 raise ValueError(
                     "inner_radius ({}) is larger than outer_radius ({})".format(
-                        value, self.outer_radius))
+                        value, self.outer_radius
+                    )
+                )
         self._inner_radius = value
 
     @property
@@ -74,7 +99,9 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             if value <= self.inner_radius:
                 raise ValueError(
                     "inner_radius ({}) is larger than outer_radius ({})".format(
-                        self.inner_radius, value))
+                        self.inner_radius, value
+                    )
+                )
         self._outer_radius = value
 
     def find_points(self):
@@ -82,10 +109,10 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             2D profile of the center column shield shape."""
 
         points = [
-            (self.inner_radius, self.height / 2),
-            (self.outer_radius, self.height / 2),
-            (self.outer_radius, -self.height / 2),
-            (self.inner_radius, -self.height / 2),
+            (self.inner_radius, self.center_height + self.height / 2),
+            (self.outer_radius, self.center_height + self.height / 2),
+            (self.outer_radius, self.center_height + (-self.height / 2)),
+            (self.inner_radius, self.center_height + (-self.height / 2)),
         ]
 
         self.points = points

--- a/paramak/parametric_components/center_column_cylinder.py
+++ b/paramak/parametric_components/center_column_cylinder.py
@@ -56,9 +56,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
         if not isinstance(value, (int, float)):
             raise TypeError(
                 "CenterColumnShieldBlock.center_height should be a float or int. Not a {}".format(
-                    type(value)
-                )
-            )
+                    type(value)))
         if value is None:
             raise ValueError(
                 "center_height of the CenterColumnShieldBlock cannot be None"
@@ -72,7 +70,8 @@ class CenterColumnShieldCylinder(RotateStraightShape):
     @height.setter
     def height(self, value):
         if value is None:
-            raise ValueError("height of the CenterColumnShieldBlock cannot be None")
+            raise ValueError(
+                "height of the CenterColumnShieldBlock cannot be None")
         self._height = value
 
     @property
@@ -85,9 +84,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             if value >= self.outer_radius:
                 raise ValueError(
                     "inner_radius ({}) is larger than outer_radius ({})".format(
-                        value, self.outer_radius
-                    )
-                )
+                        value, self.outer_radius))
         self._inner_radius = value
 
     @property
@@ -100,9 +97,7 @@ class CenterColumnShieldCylinder(RotateStraightShape):
             if value <= self.inner_radius:
                 raise ValueError(
                     "inner_radius ({}) is larger than outer_radius ({})".format(
-                        self.inner_radius, value
-                    )
-                )
+                        self.inner_radius, value))
         self._outer_radius = value
 
     def find_points(self):

--- a/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
+++ b/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
@@ -132,7 +132,7 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
             inner_radius=3,
             outer_radius=3.3,
             height=5,
-            color=(1,0,0)
+            color=(1, 0, 0)
         )
 
         test_shape2 = paramak.CenterColumnShieldCylinder(
@@ -140,7 +140,7 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
             outer_radius=3.3,
             height=5,
             center_height=-2.5,
-            color=(1,0,0)
+            color=(1, 0, 0)
         )
 
         test_shape3 = paramak.CenterColumnShieldCylinder(
@@ -148,7 +148,7 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
             outer_radius=3.3,
             height=5,
             center_height=0,
-            color=(1,0,0),
+            color=(1, 0, 0),
             cut=test_shape2
         )
 

--- a/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
+++ b/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
@@ -126,7 +126,7 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_outer_radius)
         self.assertRaises(ValueError, incorrect_height)
         self.assertRaises(TypeError, incorrect_center_height)
-        self.assertRaises(ValueError, incorrect_center_height_none)
+        self.assertRaises(TypeError, incorrect_center_height_none)
 
     def test_center_height_usage(self):
         """Makes a offset cyclinder using center_height that overlaps half of

--- a/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
+++ b/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
@@ -116,6 +116,41 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
             self.test_shape.outer_radius = 200
             self.test_shape.height = None
 
+        def incorrect_center_height():
+            self.test_shape.center_height = 'string'
+
         self.assertRaises(ValueError, incorrect_inner_radius)
         self.assertRaises(ValueError, incorrect_outer_radius)
         self.assertRaises(ValueError, incorrect_height)
+        self.assertRaises(TypeError, incorrect_center_height)
+
+    def test_center_height_usage(self):
+        """Makes a offset cyclinder using center_height that overlaps half of
+        the default center_height=0 shape. Cuts shapes and checks volumes.
+        """
+        test_shape1 = paramak.CenterColumnShieldCylinder(
+            inner_radius=3,
+            outer_radius=3.3,
+            height=5,
+            color=(1,0,0)
+        )
+
+        test_shape2 = paramak.CenterColumnShieldCylinder(
+            inner_radius=3,
+            outer_radius=3.3,
+            height=5,
+            center_height=-2.5,
+            color=(1,0,0)
+        )
+
+        test_shape3 = paramak.CenterColumnShieldCylinder(
+            inner_radius=3,
+            outer_radius=3.3,
+            height=5,
+            center_height=0,
+            color=(1,0,0),
+            cut=test_shape2
+        )
+
+        assert test_shape2.volume == test_shape1.volume
+        assert pytest.approx(test_shape3.volume) == 0.5 * test_shape1.volume

--- a/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
+++ b/tests/test_parametric_components/test_CenterColumnShieldCylinder.py
@@ -119,10 +119,14 @@ class TestCenterColumnShieldCylinder(unittest.TestCase):
         def incorrect_center_height():
             self.test_shape.center_height = 'string'
 
+        def incorrect_center_height_none():
+            self.test_shape.center_height = None
+
         self.assertRaises(ValueError, incorrect_inner_radius)
         self.assertRaises(ValueError, incorrect_outer_radius)
         self.assertRaises(ValueError, incorrect_height)
         self.assertRaises(TypeError, incorrect_center_height)
+        self.assertRaises(ValueError, incorrect_center_height_none)
 
     def test_center_height_usage(self):
         """Makes a offset cyclinder using center_height that overlaps half of


### PR DESCRIPTION
## Proposed changes

Allows the CenterColumnShieldCylinder to be shifted vertically using a new argument called ```center_height``` which defaults to 0

The following image can now be made with code like this

```python
import paramak
inner_vessel = paramak.CenterColumnShieldCylinder(
    inner_radius=3,
    outer_radius=3.3,
    height=5,
    color=(0,0,1),
    center_height=0
)

inner_vessel2 = paramak.CenterColumnShieldCylinder(
    inner_radius=3,
    outer_radius=3.3,
    height=5,
    center_height=-6,
    color=(1,0,0)
)

inner_vessel3 = paramak.CenterColumnShieldCylinder(
    inner_radius=3,
    outer_radius=3.3,
    height=5,
    center_height=6,
    color=(0,1,0)
)

r = paramak.Reactor([inner_vessel, inner_vessel2, inner_vessel3])
r.show()
```

![Screenshot 2021-07-19 150742](https://user-images.githubusercontent.com/8583900/126173239-e9f9d632-2986-4627-899c-6e1b096521c7.png)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
