### PR TITLE
added default edge color to show and html 3d export

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -313,7 +313,7 @@ class Reactor:
     def solid(self, value):
         self._solid = value
 
-    def show(self, default_edgecolor: Tuple[float, float, float] = (0,0,0)):
+    def show(self, default_edgecolor: Tuple[float, float, float] = (0, 0, 0)):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
         show from jupyter_cadquery.cadquery and returns show(Reactor.solid)
 
@@ -362,7 +362,6 @@ class Reactor:
                         color=scaled_color))
 
         return show(PartGroup(parts), default_edgecolor=scaled_edge_color)
-
 
     def neutronics_description(
             self,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -673,16 +673,16 @@ class Shape:
         result = importers.importStep(filename)
         self.solid = result
 
-    def show(self, default_edgecolor: Tuple[float, float, float] = (0,0,0)):
+    def show(self, default_edgecolor: Tuple[float, float, float] = (0, 0, 0)):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
         show from jupyter_cadquery.cadquery and returns show(Shape.solid)
-        
+
         Args:
             default_edgecolor: the color to use for the edges, passed to
                 jupyter_cadquery.cadquery show. Tuple of three values expected
                 individual values in the tuple should be floats between 0. and
                 1.
-        
+
         Returns:
             jupyter_cadquery.cadquery.show object
         """
@@ -721,7 +721,7 @@ class Shape:
                     name=f"{name}",
                     color=scaled_color,
                     show_edges=True
-                    ))
+                ))
 
         return show(PartGroup(parts), default_edgecolor=scaled_edge_color)
 


### PR DESCRIPTION
## Proposed changes

Adds a default edge color of (0,0,0) to the 3d object created with ```paramak.Shape.show()``` ,  ```paramak.Reactor.show()```  ```paramak.Shape.export_html_3d()``` ,  ```paramak.Reactor.export_html_3d()``` which makes the diagram clearer

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
