### PR TITLE
Non normal extrusion

### DIFF
--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -128,7 +128,7 @@ class ExtrudeMixedShape(Shape):
                 vecNormal=vector,
             )
 
-            toFuse = [solid]
+            to_fuse = [solid]
 
             # if extrude both, do the same in the other direction
             if self.extrude_both:
@@ -137,10 +137,10 @@ class ExtrudeMixedShape(Shape):
                     innerWires=[],
                     vecNormal=vector.multiply(-1.0),
                 )
-                toFuse.append(solid2)
+                to_fuse.append(solid2)
 
                 # create a compound
-                solid = Compound.makeCompound(toFuse)
+                solid = Compound.makeCompound(to_fuse)
             # because combine is True by default
             solid = wire._combineWithBase(solid)
 

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -14,6 +14,9 @@ class ExtrudeMixedShape(Shape):
             neutronics)
         extrude_both: If set to True, the extrusion will occur in both
             directions. Defaults to True.
+        extrusion_vector: 3-float vector defining the extrusion direction. If
+            None, the extrusion will be orthogonal to the workplane. Defaults
+            to None.
         rotation_angle: rotation angle of solid created. A cut is performed
             from rotation_angle to 360 degrees. Defaults to 360.0.
         stp_filename: Defaults to "ExtrudeMixedShape.stp".

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -119,11 +119,11 @@ class ExtrudeMixedShape(Shape):
             )
 
             # extract wires
-            wireSets = [list(wire.ctx.pendingWires)]
+            wire_sets = [list(wire.ctx.pendingWires)]
 
             # extrude
             solid = Solid.extrudeLinear(
-                outerWire=wireSets[0][0],
+                outerWire=wire_sets[0][0],
                 innerWires=[],
                 vecNormal=vector,
             )
@@ -133,7 +133,7 @@ class ExtrudeMixedShape(Shape):
             # if extrude both, do the same in the other direction
             if self.extrude_both:
                 solid2 = Solid.extrudeLinear(
-                    outerWire=wireSets[0][0],
+                    outerWire=wire_sets[0][0],
                     innerWires=[],
                     vecNormal=vector.multiply(-1.0),
                 )

--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -1,5 +1,6 @@
-
 from typing import Optional, Tuple
+
+from cadquery import Solid, Compound, Vector
 
 from paramak import Shape
 from paramak.utils import calculate_wedge_cut
@@ -8,7 +9,6 @@ from paramak.utils import calculate_wedge_cut
 class ExtrudeMixedShape(Shape):
     """Extrudes a 3d CadQuery solid from points connected with a mixture of
     straight and spline connections.
-
     Args:
         distance: the extrusion distance to use (cm units if used for
             neutronics)
@@ -18,13 +18,13 @@ class ExtrudeMixedShape(Shape):
             from rotation_angle to 360 degrees. Defaults to 360.0.
         stp_filename: Defaults to "ExtrudeMixedShape.stp".
         stl_filename: Defaults to "ExtrudeMixedShape.stl".
-
     """
 
     def __init__(
         self,
         distance: float,
         extrude_both: Optional[bool] = True,
+        extrusion_vector: Optional[Tuple[float, float, float]] = None,
         rotation_angle: Optional[float] = 360.0,
         extrusion_start_offset: Optional[float] = 0.0,
         stp_filename: Optional[str] = "ExtrudeMixedShape.stp",
@@ -43,6 +43,7 @@ class ExtrudeMixedShape(Shape):
         self.extrude_both = extrude_both
         self.rotation_angle = rotation_angle
         self.extrusion_start_offset = extrusion_start_offset
+        self.extrusion_vector = extrusion_vector
 
     @property
     def distance(self):
@@ -71,25 +72,17 @@ class ExtrudeMixedShape(Shape):
     def create_solid(self):
         """Creates an extruded 3d solid using points connected with straight
         and spline edges.
-
            Returns:
               A CadQuery solid: A 3D solid volume
         """
 
         solid = super().create_solid()
 
-        if not self.extrude_both:
-            extrusion_distance = -self.distance
-        else:
-            extrusion_distance = -self.distance / 2.0
-
         wire = solid.close()
 
         self.wire = wire
 
-        solid = wire.extrude(
-            distance=extrusion_distance,
-            both=self.extrude_both)
+        solid = self.extrude(wire)
 
         # filleting rectangular port cutter edges
         # must be done before azimuthal placement
@@ -100,5 +93,52 @@ class ExtrudeMixedShape(Shape):
         cutting_wedge = calculate_wedge_cut(self)
         solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
         self.solid = solid
+
+        return solid
+
+    def extrude(self, wire):
+        if not self.extrude_both:
+            extrusion_distance = -self.distance
+        else:
+            extrusion_distance = -self.distance / 2.0
+
+        if self.extrusion_vector is None:
+            # extrude in the normal direction
+            solid = wire.extrude(
+                distance=extrusion_distance,
+                both=self.extrude_both)
+        else:
+            # create extrusion vector
+            vector = (
+                Vector(self.extrusion_vector)
+                .normalized()
+                .multiply(extrusion_distance)
+            )
+
+            # extract wires
+            wireSets = [list(wire.ctx.pendingWires)]
+
+            # extrude
+            solid = Solid.extrudeLinear(
+                outerWire=wireSets[0][0],
+                innerWires=[],
+                vecNormal=vector,
+            )
+
+            toFuse = [solid]
+
+            # if extrude both, do the same in the other direction
+            if self.extrude_both:
+                solid2 = Solid.extrudeLinear(
+                    outerWire=wireSets[0][0],
+                    innerWires=[],
+                    vecNormal=vector.multiply(-1.0),
+                )
+                toFuse.append(solid2)
+
+                # create a compound
+                solid = Compound.makeCompound(toFuse)
+            # because combine is True by default
+            solid = wire._combineWithBase(solid)
 
         return solid

--- a/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeMixedShape.py
@@ -223,5 +223,104 @@ class TestExtrudeMixedShape(unittest.TestCase):
         assert pytest.approx(new_volume, rel=0.000001) == original_volume
 
 
+def test_non_normal_extrusion():
+    """Test that 2 shapes with opposite extrusion vectors have the same volume
+    """
+    test_shape1 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+            extrusion_vector=(1, 1, 1)
+    )
+
+    test_shape2 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+            extrusion_vector=(-1, -1, -1)
+    )
+
+    assert pytest.approx(test_shape1.volume, rel=0.000001) == test_shape2.volume
+
+
+def test_non_normal_extrusion_both():
+    """Check that 2 shapes with same extrusion vector but different
+    extrude_both args have the same volume
+    """
+    test_shape1 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+            extrusion_vector=(1, 1, 1),
+            extrude_both=False
+    )
+
+    test_shape2 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+            extrusion_vector=(1, 1, 1),
+            extrude_both=True
+    )
+
+    assert pytest.approx(test_shape1.volume, rel=0.000001) == test_shape2.volume
+
+
+def test_non_normal_compared_to_normal():
+    """Check that extrusion vector 001 is equilavent to default behaviour
+    """
+    test_shape1 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+    )
+
+    test_shape2 = ExtrudeMixedShape(
+            points=[
+                (50, 0, "straight"),
+                (50, 50, "spline"),
+                (60, 70, "spline"),
+                (70, 50, "circle"),
+                (60, 25, "circle"),
+                (70, 0, "straight")
+            ],
+            distance=50,
+            extrusion_vector=(0, 1, 0),
+            extrude_both=True
+    )
+
+    assert pytest.approx(test_shape1.volume, rel=0.000001) == test_shape2.volume
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

This PR fixes #81. Thanks @gonuke for suggesting this feature!

Users can now provide an extrusion direction (via a vector) for all the Extrude shapes (`ExtrudeMixedShape`, `ExtrudeStraightShape`, `ExtrudeCircleShape`, `ExtrudeSplineShape`).

The norm of the vector will be ignored since its normalised internally.

**Usage**
```python
from paramak import ExtrudeMixedShape

my_shape = ExtrudeMixedShape(
        points=[
            (50, 0, "straight"),
            (50, 50, "spline"),
            (60, 70, "spline"),
            (70, 50, "circle"),
            (60, 25, "circle"),
            (70, 0, "straight")
        ],
        distance=50,
        extrusion_vector=(1, 1, 1)
)
```

Produces:
![image](https://user-images.githubusercontent.com/40028739/133065264-805881df-6850-46ef-8a47-a07a39959aba.png)


Default behaviour:
![image](https://user-images.githubusercontent.com/40028739/133065427-45c1863b-024d-442a-b2ee-946f0e0707e9.png)


## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Pep8 applied
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
