### PR TITLE
Shape.workplane can now accept a cadquery.Plane object

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,7 @@ RUN apt-get --allow-releaseinfo-change update
 RUN apt-get update -y && \
     apt-get upgrade -y
 
-RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev \
-                       freeglut3-dev libosmesa6 libosmesa6-dev \
-                       libgles2-mesa-dev curl imagemagick && \
+RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev  freeglut3-dev libosmesa6 libosmesa6-dev  libgles2-mesa-dev curl imagemagick && \
                        apt-get clean
 
 # Installing CadQuery
@@ -63,7 +61,7 @@ EXPOSE 8888
 WORKDIR /home/paramak
 
 
-FROM dependencies as final
+FROM ghcr.io/fusion-energy/paramak:dependencies as final
 
 COPY run_tests.sh run_tests.sh
 COPY paramak paramak/

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -289,6 +289,8 @@ class Shape:
                 raise TypeError(
                     "Shape.workplane must be a string or a ",
                     "cadquery.Plane object")
+        else:
+            self._workplane = value
 
     @property
     def rotation_axis(self):

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -45,8 +45,8 @@ class Shape:
             azimuth angle(s) used when positioning the shape. If a list of
             angles is provided, the shape is duplicated at all angles.
             Defaults to 0.0.
-        workplane (str, optional): the orientation of the Cadquery workplane.
-            (XY, YZ or XZ). Defaults to "XZ".
+        workplane: the orientation of the Cadquery workplane. Options include
+            strings "XY", "YZ", "XZ" or a Cadquery.Plane(). Defaults to "XZ".
         rotation_axis (str or list, optional): rotation axis around which the
             solid is rotated. If None, the rotation axis will depend on the
             workplane or path_workplane if applicable. Can be set to "X", "-Y",

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
-from cadquery import Assembly, Color, Compound, Workplane, exporters, importers
+from cadquery import Assembly, Color, Compound, Workplane, exporters, importers, Plane
 from cadquery.occ_impl import shapes
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
@@ -88,7 +88,7 @@ class Shape:
         stp_filename: Optional[str] = None,
         stl_filename: Optional[str] = None,
         azimuth_placement_angle: Optional[Union[float, List[float]]] = 0.0,
-        workplane: Optional[str] = "XZ",
+        workplane: Optional[Union[str, Plane]] = "XZ",
         rotation_axis: Optional[str] = None,
         tet_mesh: Optional[str] = None,
         scale: Optional[float] = None,
@@ -276,14 +276,19 @@ class Shape:
     @workplane.setter
     def workplane(self, value):
         acceptable_values = ["XY", "YZ", "XZ", "YX", "ZY", "ZX"]
-        if value in acceptable_values:
-            self._workplane = value
-        else:
-            raise ValueError(
-                "Shape.workplane must be one of ",
-                acceptable_values,
-                " not ",
-                value)
+        if not isinstance(value, Plane):
+            if value in acceptable_values:
+                self._workplane = value
+            elif type(value) is str:
+                raise ValueError(
+                    "Shape.workplane must be one of ",
+                    acceptable_values,
+                    " not ",
+                    value)
+            else:
+                raise TypeError(
+                    "Shape.workplane must be a string or a ",
+                    "cadquery.Plane object")
 
     @property
     def rotation_axis(self):

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 import pytest
+from cadquery import Plane
 from paramak import ExtrudeStraightShape
 
 
@@ -13,6 +14,24 @@ class TestExtrudeStraightShape(unittest.TestCase):
         self.test_shape = ExtrudeStraightShape(
             points=[(10, 10), (10, 30), (30, 30), (30, 10)], distance=30
         )
+
+    def test_workplane_of_type_cadquery_plane(self):
+        """Tests that a Cadquery.Plane is accepted as a workplane entry and
+        makes a shape with the same volume as the default 'XY' workplane"""
+
+        normal_vec = (1, 1, 1)
+        workplane = Plane(origin=(0, 0, 0), xDir=(-1, 1, 0), normal=normal_vec)
+        # in future releases of CQ, origin and xDir will be optional
+
+        test_shape_2 = ExtrudeStraightShape(
+            workplane=workplane,
+            rotation_axis='X',
+            points=[(10, 10), (10, 30), (30, 30), (30, 10)], distance=30
+        )
+
+        assert isinstance(test_shape_2.workplane, Plane)
+        assert pytest.approx(test_shape_2.volume, self.test_shape.volume)    
+
 
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeStraightShape are correct."""

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -3,10 +3,11 @@ import json
 import os
 import unittest
 from pathlib import Path
-from numpy.testing._private.utils import assert_
 
 import paramak
 import pytest
+from cadquery import Plane
+from numpy.testing._private.utils import assert_
 
 
 class TestShape(unittest.TestCase):
@@ -645,6 +646,19 @@ class TestShape(unittest.TestCase):
         self.assertRaises(ValueError, tet_mesh_float)
         self.assertRaises(ValueError, tet_mesh_int)
         self.assertRaises(ValueError, tet_mesh_list)
+
+    def test_workplane_of_type_cadquery_plane(self):
+        """Tests that a Cadquery.Plane is accepted as a workplane entry"""
+
+        normal_vec = (1, 1, 1)
+        workplane = Plane(origin=(0, 0, 0), xDir=(-1, 1, 0), normal=normal_vec)
+        # in future releases of CQ, origin and xDir will be optional
+
+        test_shape = paramak.Shape(
+            workplane=workplane,
+        )
+
+        assert isinstance(test_shape.workplane, Plane)
 
     def test_get_rotation_axis(self):
         """Creates a shape and test the expected rotation_axis is the correct


### PR DESCRIPTION
## Proposed changes

Linked to #81.

This PR allows user to define the workplane from a cadquery.Plane object, which is defined by an origin point and a normal vector.

This normal vector is then the extrusion vector.

**Usage**

```python
import paramak
from cadquery import Plane


points = [
    (0, 0),
    (1, 0),
    (1, 1),
    (0, 1)
]

# normal shape
shape_1 = paramak.ExtrudeStraightShape(points=points, distance=1)

# shape with vector-defined workplane
normal_vec = (1, 1, 1)
workplane = Plane(origin=(0, 0, 0), xDir=(-1, 1, 0), normal=normal_vec)
# in future releases of CQ, origin and xDir will be optional

shape_2 = paramak.ExtrudeStraightShape(
    points=points, distance=1,
    workplane=workplane,
    rotation_axis='X')

# export shapes
shape_1.export_stl('non_rotated.stl')  # white
shape_2.export_stl('rotated.stl')  # red
```
![image](https://user-images.githubusercontent.com/40028739/133099516-4551f686-28d4-4dc8-bca5-ddbae1034096.png)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
