### PR TITLE
Adding names to reactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,18 +61,19 @@ EXPOSE 8888
 WORKDIR /home/paramak
 
 
-FROM ghcr.io/fusion-energy/paramak:dependencies as final
+# FROM ghcr.io/fusion-energy/paramak:dependencies as final
+FROM dependencies as final
 
+COPY README.md README.md
 COPY run_tests.sh run_tests.sh
 COPY paramak paramak/
 COPY examples examples/
 COPY setup.py setup.py
 COPY tests tests/
-COPY README.md README.md
 
 # using setup.py instead of pip due to https://github.com/pypa/pip/issues/5816
 RUN python setup.py install
 
 # this helps prevent the kernal failing
-RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh
-CMD bash docker-cmd.sh
+# RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh
+# CMD bash docker-cmd.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,19 +61,18 @@ EXPOSE 8888
 WORKDIR /home/paramak
 
 
-# FROM ghcr.io/fusion-energy/paramak:dependencies as final
-FROM dependencies as final
+FROM ghcr.io/fusion-energy/paramak:dependencies as final
 
-COPY README.md README.md
 COPY run_tests.sh run_tests.sh
 COPY paramak paramak/
 COPY examples examples/
 COPY setup.py setup.py
 COPY tests tests/
+COPY README.md README.md
 
 # using setup.py instead of pip due to https://github.com/pypa/pip/issues/5816
 RUN python setup.py install
 
 # this helps prevent the kernal failing
-# RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh
-# CMD bash docker-cmd.sh
+RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh
+CMD bash docker-cmd.sh

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -243,6 +243,17 @@ class Reactor:
 
         return compound
 
+    @property
+    def name(self):
+        """Returns a list of names of the individual Shapes that make up the
+        reactor """
+
+        all_names = []
+        for shape in self.shapes_and_components:
+            all_names.append(shape.name)
+
+        return all_names
+
     @ solid.setter
     def solid(self, value):
         self._solid = value
@@ -372,7 +383,8 @@ class Reactor:
 
     def material_tags(
             self,
-            include_plasma: Optional[bool] = False
+            include_plasma: Optional[bool] = False,
+            allow_repeats: Optional[bool] = True,
     ) -> List[str]:
         """Returns a set of all the materials_tags used in the Reactor
         optionally with or without the plasma.
@@ -380,6 +392,9 @@ class Reactor:
         Args:
             include_plasma: Should the plasma material be included in the list
                 of materials returned.
+            allow_repeats: Material tags for individual shapes could be the
+                same. This flag allows repeat occurrences to be removed (False)
+                or kept (True).
 
         Returns:
             A list of the material tags
@@ -396,7 +411,12 @@ class Reactor:
             else:
                 values.append(shape_or_component.material_tag)
 
-        return values
+        if allow_repeats is False:
+            return list(set(values))
+        elif allow_repeats is True:
+            return values
+        else:
+            raise ValueError('allow_repeats must be either True or False')
 
     def export_neutronics_description(
             self,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -381,7 +381,7 @@ class Reactor:
 
         return neutronics_description
 
-    def material_tags(
+    def material_tag(
             self,
             include_plasma: Optional[bool] = False,
             allow_repeats: Optional[bool] = True,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1296,10 +1296,10 @@ class Shape:
             dictionary: a dictionary of the step filename and material name
         """
 
-        neutronics_description = {
-            "material_tag": self.material_tag,
-            "volume": self.volume(split_compounds=True),
-        }
+        neutronics_description = {"material_tag": self.material_tag}
+
+        if self.solid is not None:
+            neutronics_description["volume"] = self.volume(split_compounds=True)
 
         if self.stp_filename is not None:
             neutronics_description["stp_filename"] = self.stp_filename

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1299,7 +1299,8 @@ class Shape:
         neutronics_description = {"material_tag": self.material_tag}
 
         if self.solid is not None:
-            neutronics_description["volume"] = self.volume(split_compounds=True)
+            neutronics_description["volume"] = self.volume(
+                split_compounds=True)
 
         if self.stp_filename is not None:
             neutronics_description["stp_filename"] = self.stp_filename

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1296,7 +1296,10 @@ class Shape:
             dictionary: a dictionary of the step filename and material name
         """
 
-        neutronics_description = {"material_tag": self.material_tag}
+        neutronics_description = {
+            "material_tag": self.material_tag,
+            "volume": self.volume(split_compounds=True),
+        }
 
         if self.stp_filename is not None:
             neutronics_description["stp_filename"] = self.stp_filename

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -16,7 +16,8 @@ class TestExtrudeStraightShape(unittest.TestCase):
 
     def test_volume_in_neutronics_description(self):
         assert 'volume' in self.test_shape.neutronics_description()[0].keys()
-        assert pytest.approx(self.test_shape.neutronics_description()[0]['volume'][0], 1200)
+        assert pytest.approx(
+            self.test_shape.neutronics_description()[0]['volume'][0], 1200)
 
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeStraightShape are

--- a/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
+++ b/tests/test_parametric_shapes/test_ExtrudeStraightShape.py
@@ -14,6 +14,10 @@ class TestExtrudeStraightShape(unittest.TestCase):
             points=[(10, 10), (10, 30), (30, 30), (30, 10)], distance=30
         )
 
+    def test_volume_in_neutronics_description(self):
+        assert 'volume' in self.test_shape.neutronics_description()[0].keys()
+        assert pytest.approx(self.test_shape.neutronics_description()[0]['volume'][0], 1200)
+
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeStraightShape are
         correct."""

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -1218,5 +1218,6 @@ class TestReactor(unittest.TestCase):
 
         self.assertRaises(ValueError, test_inccorect_allow_repeat)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -1204,7 +1204,7 @@ class TestReactor(unittest.TestCase):
 
     def test_reactor_material_tag(self):
         'checks that the material_tag attribute returns the expected results'
-        assert self.test_reactor_2.material_tag == ['mat1', 'mat1']
+        assert self.test_reactor_2.material_tag() == ['mat1', 'mat1']
         assert self.test_reactor_2.material_tag(
             allow_repeats=False) == ['mat1']
 

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -1205,7 +1205,9 @@ class TestReactor(unittest.TestCase):
     def test_reactor_material_tag(self):
         'checks that the material_tag attribute returns the expected results'
         assert self.test_reactor_2.material_tag == ['mat1', 'mat1']
-        assert self.test_reactor_2.material_tag(allow_repeats=False) == ['mat1']
+        assert self.test_reactor_2.material_tag(
+            allow_repeats=False) == ['mat1']
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -1208,6 +1208,15 @@ class TestReactor(unittest.TestCase):
         assert self.test_reactor_2.material_tag(
             allow_repeats=False) == ['mat1']
 
+    def test_incorrect_repeat_raises_error(self):
+        """Finds the materials with the wrong type of allow_repeat"""
+
+        def test_inccorect_allow_repeat():
+            """checks ValueError is raised"""
+
+            self.test_reactor_2.material_tag(allow_repeats='yes') == ['mat1']
+
+        self.assertRaises(ValueError, test_inccorect_allow_repeat)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -13,10 +13,16 @@ class TestReactor(unittest.TestCase):
 
     def setUp(self):
         self.test_shape = paramak.RotateStraightShape(
-            points=[(0, 0), (0, 20), (20, 20)])
+            points=[(0, 0), (0, 20), (20, 20)],
+            material_tag='mat1',
+            name='test_shape'
+        )
 
         self.test_shape2 = paramak.ExtrudeStraightShape(
-            points=[(100, 100), (50, 100), (50, 50)], distance=20)
+            points=[(100, 100), (50, 100), (50, 50)], distance=20,
+            material_tag='mat1',
+            name='test_shape2'
+        )
 
         test_shape_3 = paramak.PoloidalFieldCoilSet(
             heights=[2, 2],
@@ -131,8 +137,8 @@ class TestReactor(unittest.TestCase):
         test_shape.rotation_angle = 360
         test_shape.create_solid()
         test_reactor = paramak.Reactor([test_shape])
-        assert len(test_reactor.material_tags()) == 1
-        assert test_reactor.material_tags()[0] == "mat1"
+        assert len(test_reactor.material_tag()) == 1
+        assert test_reactor.material_tag()[0] == "mat1"
 
     def test_adding_plasma_with_material_tag_to_reactor(self):
         """Checks that a shape object can be added to a Reactor object with
@@ -142,8 +148,8 @@ class TestReactor(unittest.TestCase):
             points=[(0, 0), (0, 20), (20, 20)], material_tag="dt_plasma", name='plasma'
         )
         test_reactor = paramak.Reactor([test_shape])
-        assert len(test_reactor.material_tags()) == 1
-        assert test_reactor.material_tags()[0] == "dt_plasma"
+        assert len(test_reactor.material_tag()) == 1
+        assert test_reactor.material_tag()[0] == "dt_plasma"
 
     def test_adding_multiple_shapes_with_material_tag_to_reactor(self):
         """Checks that multiple shape objects can be added to a Reactor object
@@ -158,11 +164,11 @@ class TestReactor(unittest.TestCase):
         test_shape.rotation_angle = 360
         test_shape.create_solid()
         test_reactor = paramak.Reactor([test_shape, test_shape2])
-        assert len(test_reactor.material_tags()) == 2
-        assert "mat1" in test_reactor.material_tags()
-        assert "mat2" in test_reactor.material_tags()
+        assert len(test_reactor.material_tag()) == 2
+        assert "mat1" in test_reactor.material_tag()
+        assert "mat2" in test_reactor.material_tag()
 
-    def test_material_tags_without_plasma(self):
+    def test_material_tag_without_plasma(self):
         """Checks that the material tags don't contain the plasma when it is filtered out"""
 
         test_shape = paramak.RotateStraightShape(
@@ -172,9 +178,9 @@ class TestReactor(unittest.TestCase):
 
         test_reactor = paramak.Reactor([test_shape, test_shape2])
 
-        assert len(test_reactor.material_tags(include_plasma=False)) == 1
-        assert "mat1" in test_reactor.material_tags()
-        assert "plasma" not in test_reactor.material_tags()
+        assert len(test_reactor.material_tag(include_plasma=False)) == 1
+        assert "mat1" in test_reactor.material_tag()
+        assert "plasma" not in test_reactor.material_tag()
 
     def test_make_sector_wedge(self):
         """Checks that the wedge is not made when rotation angle is 360"""
@@ -1192,6 +1198,14 @@ class TestReactor(unittest.TestCase):
         vol_3 = self.test_reactor_3.volume(split_compounds=False)[1]
         assert pytest.approx(vol_3, vol_1 + vol_2)
 
+    def test_reactor_names(self):
+        'checks that the names attribute returns the expected results'
+        assert self.test_reactor_2.name == ['test_shape', 'test_shape2']
+
+    def test_reactor_material_tag(self):
+        'checks that the material_tag attribute returns the expected results'
+        assert self.test_reactor_2.material_tag == ['mat1', 'mat1']
+        assert self.test_reactor_2.material_tag(allow_repeats=False) == ['mat1']
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes

This PR adds ```.name``` attributes to the Reactor class that returns all the names of the shapes.
 ```reactor.material_tags()``` has been renamed ``` ```reactor.material_tag()``` to be consistent with the Shape class
also allows keyword ```allow_repeat``` to b passed to ```reactor.material_tag()``` if one just wants to know the set() of tags
extra tests to cover the new code have been added

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
