### PR TITLE
export graveyard now defaults to false

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -326,8 +326,8 @@ class Reactor:
     def neutronics_description(
             self,
             include_plasma: Optional[bool] = False,
-            include_graveyard: Optional[bool] = True,
-            include_sector_wedge: Optional[bool] = True,
+            include_graveyard: Optional[bool] = False,
+            include_sector_wedge: Optional[bool] = False,
     ) -> dict:
         """A description of the reactor containing material tags, stp filenames,
         and tet mesh instructions. This is used for neutronics simulations
@@ -439,7 +439,7 @@ class Reactor:
             self,
             filename: Optional[str] = "manifest.json",
             include_plasma: Optional[bool] = False,
-            include_graveyard: Optional[bool] = True,
+            include_graveyard: Optional[bool] = False,
             include_sector_wedge: Optional[bool] = False,
     ) -> str:
         """
@@ -499,8 +499,8 @@ class Reactor:
             self,
             output_folder: Optional[str] = "",
             mode: Optional[str] = 'solid',
-            include_graveyard: Optional[bool] = True,
-            include_sector_wedge: Optional[bool] = True,
+            include_graveyard: Optional[bool] = False,
+            include_sector_wedge: Optional[bool] = False,
             units: Optional[str] = 'mm',
             filename: Optional[str] = None
     ) -> List[str]:
@@ -512,19 +512,19 @@ class Reactor:
             mode: the object to export can be either 'solid' which exports 3D
                 solid shapes or the 'wire' which exports the wire edges of the
                 shape.
-            include_graveyard: specifiy if the graveyard will be included or
+            include_graveyard: specify if the graveyard will be included or
                 not. If True the the Reactor.make_graveyard will be called
                 using Reactor.graveyard_size and Reactor.graveyard_offset
                 attribute values.
             include_sector_wedge: specifies if a sector_wedge will be exported.
-                This wedge is useful when constructing reflectin surfaces in
-                DAGMC geometry. If set to True the the self.rotation_agle must
+                This wedge is useful when constructing reflecting surfaces in
+                DAGMC geometry. If set to True the the self.rotation_angle must
                 also be set.
             units: the units of the stp file, options are 'cm' or 'mm'.
                 Default is mm.
             filename: If specified all the shapes will be combined into a
-                single file. If left as Default (None) then the seperate shapes
-                are saved as seperate files using their shape.stp_filename
+                single file. If left as Default (None) then the separate shapes
+                are saved as separate files using their shape.stp_filename
                 attribute. output_folder is ignored if filename is set.
         Returns:
             list: a list of stp filenames created
@@ -595,14 +595,14 @@ class Reactor:
             self,
             output_folder: Optional[str] = "",
             tolerance: Optional[float] = 0.001,
-            include_graveyard: Optional[bool] = True,
+            include_graveyard: Optional[bool] = False,
     ) -> List[str]:
         """Writes stl files (CAD geometry) for each Shape object in the reactor
 
         Args:
             output_folder (str): the folder for saving the stl files to
             tolerance (float):  the precision of the faceting
-            include_graveyard: specifiy if the graveyard will be included or
+            include_graveyard: specify if the graveyard will be included or
                 not. If True the the Reactor.make_graveyard will be called
                 using Reactor.graveyard_size and Reactor.graveyard_offset
                 attribute values.
@@ -658,9 +658,9 @@ class Reactor:
 
         Args:
             height: The height of the rotated wedge. If None then the
-                largest_dimention of the model will be used.
+                largest_dimension of the model will be used.
             radius: The radius of the rotated wedge. If None then the
-                largest_dimention of the model will be used
+                largest_dimension of the model will be used
             rotation_angle: The rotation angle of the wedge will be the
                 inverse of the sector
             stp_filename:
@@ -823,7 +823,7 @@ class Reactor:
         """Writes a stp file (CAD geometry) for the reactor graveyard. This
         is needed for DAGMC simulations. This method also calls
         Reactor.make_graveyard() with the graveyard_size and graveyard_size
-        vaules.
+        values.
 
         Args:
             filename (str): the filename for saving the stp file. Appends
@@ -895,7 +895,7 @@ class Reactor:
         else:
             raise ValueError("the graveyard_size, Reactor.graveyard_size, \
                 graveyard_offset and Reactor.graveyard_offset are all None. \
-                Please specify at least one of these attributes or agruments")
+                Please specify at least one of these attributes or arguments")
 
         graveyard_shape = paramak.HollowCube(
             length=graveyard_size_to_use,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -442,7 +442,9 @@ class Shape:
 
     @property
     def processed_points(self):
-        """Shape.processed_points attributes is set internally from the Shape.points"""
+        """Shape.processed_points attributes is set internally from the
+        Shape.points"""
+
         if self.points is not None:
             # if .points have changed since last time this was run
             if self.old_points != self.points:
@@ -1338,21 +1340,11 @@ class Shape:
         neutronics model. Creating of the neutronics model requires linkage
         between volumes, materials and identification of which volumes to
         tet_mesh. If the filename does not end with .json then .json will be
-        added. The plasma geometry is not included by default as it is
-        typically not included in neutronics simulations. The reason for this
-        is that the low number density results in minimal interactions with
-        neutrons. However, the plasma can be added if the include_plasma
-        argument is set to True.
+        added.
 
         Args:
             filename (str, optional): the filename used to save the neutronics
                 description
-            include_plasma (Boolean, optional): should the plasma be included.
-                Defaults to False as the plasma volume and material has very
-                little impact on the neutronics results due to the low density.
-                Including the plasma does however slow down the simulation.
-            include_graveyard (Boolean, optional): should the graveyard be
-                included. Defaults to True as this is needed for DAGMC models.
         """
 
         path_filename = Path(filename)

--- a/tests/test_parametric_reactors/test_eu_demo_2015_reactor.py
+++ b/tests/test_parametric_reactors/test_eu_demo_2015_reactor.py
@@ -61,7 +61,7 @@ class TestDemo2015Reactor(unittest.TestCase):
         ]
         os.system("rm *.stp")
         my_reactor = paramak.EuDemoFrom2015PaperDiagram(number_of_tf_coils=1)
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
         os.system("rm *.stp")
@@ -87,7 +87,7 @@ class TestDemo2015Reactor(unittest.TestCase):
         os.system("rm *.stp")
         my_reactor = paramak.EuDemoFrom2015PaperDiagram(
             number_of_tf_coils=1, rotation_angle=90)
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
         os.system("rm *.stp")

--- a/tests/test_parametric_reactors/test_iter_reactor.py
+++ b/tests/test_parametric_reactors/test_iter_reactor.py
@@ -44,7 +44,7 @@ class TestITERReactor(unittest.TestCase):
             assert component.volume() > 0
 
     def test_make_demo_2015_reactor(self):
-        """Creates a ITERTokamak reactor and eports the stp
+        """Creates a ITERTokamak reactor and exports the stp
         files checking that each component results in a stp file"""
 
         output_filenames = [
@@ -63,14 +63,14 @@ class TestITERReactor(unittest.TestCase):
         ]
         os.system("rm *.stp")
         my_reactor = paramak.IterFrom2020PaperDiagram(number_of_tf_coils=1)
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
         os.system("rm *.stp")
 
     def test_make_parametric_demo_2015_rector(self):
-        """Creates a ITERTokamak reactor with a non defulat
-        rotation angle and eports the stp files checking that each component
+        """Creates a ITERTokamak reactor with a non defaults
+        rotation angle and exports the stp files checking that each component
         results in a stp file"""
 
         output_filenames = [
@@ -90,7 +90,7 @@ class TestITERReactor(unittest.TestCase):
         os.system("rm *.stp")
         my_reactor = paramak.IterFrom2020PaperDiagram(
             number_of_tf_coils=1, rotation_angle=90)
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in output_filenames:
             assert Path(output_filename).exists() is True
         os.system("rm *.stp")

--- a/tests/test_parametric_reactors/test_sparc_2020_reactor.py
+++ b/tests/test_parametric_reactors/test_sparc_2020_reactor.py
@@ -57,7 +57,7 @@ class TestSparc2020Reactor(unittest.TestCase):
         """Runs the example to check the output files are produced"""
         os.system("rm *.stp")
         my_reactor = paramak.SparcFrom2020PaperDiagram()
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in self.output_filenames:
             assert Path(output_filename).exists() is True
 
@@ -67,6 +67,6 @@ class TestSparc2020Reactor(unittest.TestCase):
 
         os.system("rm *.stp")
         my_reactor = paramak.SparcFrom2020PaperDiagram(rotation_angle=90)
-        my_reactor.export_stp()
+        my_reactor.export_stp(include_graveyard=True)
         for output_filename in self.output_filenames:
             assert Path(output_filename).exists() is True

--- a/tests/test_parametric_reactors/test_submersion_tokamak.py
+++ b/tests/test_parametric_reactors/test_submersion_tokamak.py
@@ -89,7 +89,9 @@ class TestSubmersionTokamak(unittest.TestCase):
         can be exported using the export_stp method."""
 
         os.system("rm -r minimal_SubmersionTokamak")
-        self.test_reactor.export_stp("minimal_SubmersionTokamak")
+        self.test_reactor.export_stp(
+            "minimal_SubmersionTokamak", include_graveyard=True
+        )
 
         output_filenames = [
             "minimal_SubmersionTokamak/inboard_tf_coils.stp",
@@ -119,7 +121,9 @@ class TestSubmersionTokamak(unittest.TestCase):
         self.test_reactor.pf_coil_radial_position = [100, 100]
         self.test_reactor.pf_coil_vertical_position = [100, -100]
 
-        self.test_reactor.export_stp("pf_SubmersionTokamak")
+        self.test_reactor.export_stp(
+            "pf_SubmersionTokamak", include_graveyard=True
+        )
 
         output_filenames = [
             "pf_SubmersionTokamak/inboard_tf_coils.stp",
@@ -153,7 +157,9 @@ class TestSubmersionTokamak(unittest.TestCase):
         self.test_reactor.pf_coil_case_thicknesses = 10
         self.test_reactor.number_of_tf_coils = 4
 
-        self.test_reactor.export_stp("tf_pf_SubmersionTokamak")
+        self.test_reactor.export_stp(
+            "tf_pf_SubmersionTokamak", include_graveyard=True
+        )
 
         output_filenames = [
             "tf_pf_SubmersionTokamak/inboard_tf_coils.stp",

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -593,7 +593,9 @@ class TestReactor(unittest.TestCase):
         test_shape.stp_filename = "test_shape.stp"
         test_reactor = paramak.Reactor([test_shape])
 
-        test_reactor.export_stp(output_folder="test_reactor")
+        test_reactor.export_stp(
+            output_folder="test_reactor", include_graveyard=True
+        )
 
         assert Path("test_reactor/test_shape.stp").exists() is True
         assert Path("test_reactor/graveyard.stp").exists() is True
@@ -611,7 +613,9 @@ class TestReactor(unittest.TestCase):
         test_shape.stl_filename = "test_shape.stl"
         test_reactor = paramak.Reactor([test_shape])
 
-        test_reactor.export_stl(output_folder="test_reactor")
+        test_reactor.export_stl(
+            output_folder="test_reactor", include_graveyard=True
+        )
 
         for filepath in [
             "test_reactor/test_shape.stl",
@@ -721,7 +725,9 @@ class TestReactor(unittest.TestCase):
         test_shape.material_tag = "test_material"
         test_shape.stp_filename = "test.stp"
         test_reactor = paramak.Reactor([test_shape])
-        neutronics_description = test_reactor.neutronics_description()
+        neutronics_description = test_reactor.neutronics_description(
+            include_graveyard=True
+        )
 
         assert len(neutronics_description) == 2
         assert "stp_filename" in neutronics_description[0].keys()
@@ -746,7 +752,7 @@ class TestReactor(unittest.TestCase):
         test_shape.tet_mesh = "size 60"
         test_reactor = paramak.Reactor([test_shape])
         returned_filename = test_reactor.export_neutronics_description(
-            filename="manifest_test.json"
+            filename="manifest_test.json", include_graveyard=True
         )
         with open("manifest_test.json") as json_file:
             neutronics_description = json.load(json_file)
@@ -897,7 +903,9 @@ class TestReactor(unittest.TestCase):
         test_shape.tet_mesh = "size 60"
         test_plasma = paramak.Plasma(major_radius=500, minor_radius=100)
         test_reactor = paramak.Reactor([test_shape, test_plasma])
-        returned_filename = test_reactor.export_neutronics_description()
+        returned_filename = test_reactor.export_neutronics_description(
+            include_graveyard=True
+        )
         with open("manifest.json") as json_file:
             neutronics_description = json.load(json_file)
 


### PR DESCRIPTION
## Proposed changes


This PR changes the default state to False for the ```inculde_graveyard``` in ```export_stp```, ```export_stl``` and ```export_neutronics_description``` 

As we are now using CSG surfaces for the graveyard in the ```openmc-dagmc-wrapper``` the main use case no longer requires a graveyard.
This has other benefits such as improved visualisation, less time needed to make geometry (make graveyard is the slowest part)

A graveyard can still be made by anyone requiring a graveyard by setting ```include_graveyard``` to true

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
