### PR TITLE
Adding brep export to shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.stp
 *.step
 *.stl
+*.brep
 
 # output files such as neutronics description files
 *.json

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@
 The Paramak python package allows rapid production of 3D CAD models of fusion
 reactors. The purpose of the Paramak is to provide geometry for parametric
 studies. The paramak can created geometry in standard CAD formats such as STP,
-STL. It can also create h5m files for 
-[DAGMC](https://svalinn.github.io/DAGMC/) and carry out neutronics simulations
-when used with the optional [paramak-neutronics](https://github.com/fusion-energy/paramak-neutronics)
-module.
+STL and Brep.
 
 :point_right: [Documentation](https://paramak.readthedocs.io)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,19 +18,12 @@ Paramak
 
 The Paramak python package allows rapid production of 3D CAD models of fusion
 reactors. The purpose of the Paramak is to provide geometry for parametric
-studies. It is possible to use the created geometry in engineering and
-neutronics studies as the STP files produced can be automatically converted to
-DAGMC compatible neutronics models or meshed and used in finite element
-analysis codes.
+studies in a varity of CAD formats including STL, STP and Brep files.
 
-Features have been added to address particular needs and the software is by no
-means a finished product. Contributions are welcome. CadQuery functions provide
-the majority of the features, and incorporating additional capabilities is
-straightforward for developers with Python knowledge.
+adQuery functions provide the majority of the features, and incorporating
+additional capabilities is straightforward for developers with Python knowledge.
 
-You might also be interested in the `paramak-neutronics <https://github.com/fusion-energy/paramak-neutronics>`_   
-which is a separate module that adds neutronics capabilties.
-
+Contributions are welcome. C
 
 .. raw:: html
 
@@ -63,8 +56,7 @@ became open-source and has flourished ever since.
 
 The project has grown largely due to two contributors in particular
 (John Billingsley and Remi Delaporte-Mathurin) and others have also helped,
-you can see all those who have helped the development in the 
-`Authors.md <https://github.com/fusion-energy/paramak/blob/main/AUTHORS.md>`_ and in the 
+you can see all those who have helped the development in the
 `GitHub contributions <https://github.com/fusion-energy/paramak/graphs/contributors>`_.
 
 The code has been professionally reviewed by
@@ -97,12 +89,12 @@ be accomplished via the use of parametric Shapes, parametric Components and
 parametric Reactors with each level building upon the level below.
 
 Parametric Shapes are the simplest and accept points and connection information
-in 2D space (defaults to x,z) and performs operations on them to create 3D
+in 2D space (defaults to x,z plane) and performs operations on them to create 3D
 volumes. The points and connections are provided by the user when making
-parametric Shapes. Supported CAD opperations include (rotate, extrude, sweep)
-and Boolean opperations such as cut, union and intersect. Additionally the 
+parametric Shapes. Supported CAD operations include (rotate, extrude, sweep)
+and Boolean operations such as cut, union and intersect. Additionally the 
 CadQuery objects created can be combined and modified using CadQuery's powerful 
-filtering capabilties to furter customise the shapes by performing operations
+filtering capabilities to further customise the shapes by performing operations
 like edge filleting.
 
 Parametric Components build on top of this foundation and will calculate the
@@ -111,8 +103,8 @@ differ between components as a center column requires different inputs to a
 breeder blanket or a magnet.
 
 Parametric Reactors build upon these two lower level objects to create an
-entire reactor model from input parameters. Linkage between the componets is
-encoded in each parametric Ractor design.
+entire reactor model from input parameters. Linkage between the components is
+encoded in each parametric Rector design.
 
 The different parametric reactor families are shown below.
 

--- a/paramak/parametric_components/toroidal_field_coil_round_corners.py
+++ b/paramak/parametric_components/toroidal_field_coil_round_corners.py
@@ -1,5 +1,4 @@
 from typing import Optional, Tuple, Union
-from _pytest.python_api import raises
 
 import cadquery as cq
 import numpy as np

--- a/paramak/parametric_reactors/cylinder_reactor.py
+++ b/paramak/parametric_reactors/cylinder_reactor.py
@@ -1,3 +1,4 @@
+
 from typing import List, Optional
 
 import paramak

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -8,7 +8,8 @@ from typing import List, Optional, Tuple, Union
 
 import cadquery as cq
 import matplotlib.pyplot as plt
-from cadquery import exporters, Compound
+from cadquery import Compound, exporters
+from OCP.BRepTools import BRepTools
 
 import paramak
 from paramak.utils import _replace, get_hash
@@ -590,6 +591,30 @@ class Reactor:
                 'SI_UNIT(.CENTI.,.METRE.)')
 
         return [filename]
+
+# TODO reactor geomety (cq.Compound) export as a brep file.
+# current error is AttributeError: 'Compound' object has no attribute 'toOCC'
+    # def export_brep(
+    #     self,
+    #     filename
+    # ):
+    #     """Exports a brep file for the Shape.solid. If the provided filename
+    #     doesn't end with .brep it will be added.
+
+    #     Args:
+    #         filename: the filename of exported the brep file.
+    #     """
+
+    #     path_filename = Path(filename)
+
+    #     if path_filename.suffix != ".brep":
+    #         path_filename = path_filename.with_suffix(".brep")
+
+    #     path_filename.parents[0].mkdir(parents=True, exist_ok=True)
+
+    #     BRepTools.Write_s(self.solid.toOCC(), path_filename)
+
+    #     return str(path_filename)
 
     def export_stl(
             self,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -946,7 +946,7 @@ class Shape:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        BRepTools.Write_s(self.solid.toOCC(), path_filename)
+        BRepTools.Write_s(self.solid.toOCC(), str(path_filename))
 
         return str(path_filename)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -932,8 +932,7 @@ class Shape:
         self,
         filename
     ):
-        """Exports a brep file for the Shape.solid. If the provided filename
-        doesn't end with .brep it will be added.
+        """Exports a brep file for the Shape.solid.
 
         Args:
             filename: the filename of exported the brep file.
@@ -942,7 +941,8 @@ class Shape:
         path_filename = Path(filename)
 
         if path_filename.suffix != ".brep":
-            path_filename = path_filename.with_suffix(".brep")
+            msg = "When exporting a brep file the filename must end with .brep"
+            raise ValueError(msg)
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
-from cadquery import Assembly, Color, Compound, Workplane, exporters, importers, Plane
+from cadquery import (Assembly, Color, Compound, Plane, Workplane, exporters,
+                      importers)
 from cadquery.occ_impl import shapes
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
+from OCP.BRepTools import BRepTools
 
 import paramak
 from paramak.utils import (_replace, cut_solid, facet_wire, get_hash,
@@ -923,6 +925,28 @@ class Shape:
 
         if verbose:
             print("Saved file as ", path_filename)
+
+        return str(path_filename)
+
+    def export_brep(
+        self,
+        filename
+    ):
+        """Exports a brep file for the Shape.solid. If the provided filename
+        doesn't end with .brep it will be added.
+
+        Args:
+            filename: the filename of exported the brep file.
+        """
+
+        path_filename = Path(filename)
+
+        if path_filename.suffix != ".brep":
+            path_filename = path_filename.with_suffix(".brep")
+
+        path_filename.parents[0].mkdir(parents=True, exist_ok=True)
+
+        BRepTools.Write_s(self.solid.toOCC(), path_filename)
 
         return str(path_filename)
 

--- a/tests/test_parametric_shapes/test_sweep_straight_shape.py
+++ b/tests/test_parametric_shapes/test_sweep_straight_shape.py
@@ -107,6 +107,29 @@ class TestSweepStraightShape(unittest.TestCase):
 
         os.system("rm test_solid.stp test_solid2.stp test_wire.stp")
 
+    def test_export_brep(self):
+        """Exports a brep file and checks that the output exist"""
+
+        os.system("rm test_solid.brep")
+
+        self.test_shape.export_brep(filename='test_solid.brep')
+
+        assert Path("test_solid.brep").exists() is True
+
+        os.system("rm test_solid.brep")
+
+    def test_export_brep(self):
+        """Exports a brep file without the extention and checks that the
+        output exist"""
+
+        os.system("rm test_solid_missing.brep")
+
+        self.test_shape.export_brep(filename='test_solid_missing')
+
+        assert Path("test_solid_missing.brep").exists() is True
+
+        os.system("rm test_solid_missing.brep")
+
     def test_incorrect_points_input(self):
         """Checks that an error is raised when the points are input with the
         connection"""

--- a/tests/test_parametric_shapes/test_sweep_straight_shape.py
+++ b/tests/test_parametric_shapes/test_sweep_straight_shape.py
@@ -118,17 +118,18 @@ class TestSweepStraightShape(unittest.TestCase):
 
         os.system("rm test_solid.brep")
 
-    def test_export_brep(self):
+    def test_export_brep_without_extention(self):
         """Exports a brep file without the extention and checks that the
         output exist"""
 
-        os.system("rm test_solid_missing.brep")
+        def missing_extention():
 
-        self.test_shape.export_brep(filename='test_solid_missing')
+            self.test_shape.export_brep(filename='test_solid_missing')
 
-        assert Path("test_solid_missing.brep").exists() is True
-
-        os.system("rm test_solid_missing.brep")
+        self.assertRaises(
+            ValueError,
+            missing_extention
+        )
 
     def test_incorrect_points_input(self):
         """Checks that an error is raised when the points are input with the


### PR DESCRIPTION
## Proposed changes

Adding ```paramak.Shape.export_brep()``` to the code. This allows a ```Shape``` to be exported. Currently reactors can't be exported in this format but perhaps this will happen in the future.

These two issues where useful when making this feature 

https://github.com/CadQuery/cadquery/issues/449
https://github.com/CadQuery/cadquery/issues/697

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
