### PR TITLE
Adding merge option to brep export

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -368,7 +368,7 @@ class Reactor:
 
             bldr.Perform()
 
-            im = bldr.Images()
+            bldr.Images()
 
             merged = cq.Compound(bldr.Shape())
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -339,7 +339,7 @@ class Reactor:
 
         return filename
 
-    def export_brep(self, filename: str, merged: bool = True):
+    def export_brep(self, filename: str, merge: bool = True):
         """Exports a brep file for the Reactor.solid.
 
         Args:
@@ -355,7 +355,7 @@ class Reactor:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        if merged == False:
+        if merge == False:
             self.solid.exportBrep(str(path_filename))
         else:
             import OCP

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -355,7 +355,7 @@ class Reactor:
 
         path_filename.parents[0].mkdir(parents=True, exist_ok=True)
 
-        if merge == False:
+        if not merge:
             self.solid.exportBrep(str(path_filename))
         else:
             import OCP

--- a/tests/test_parametric_reactors/test_cylinder_reactor.py
+++ b/tests/test_parametric_reactors/test_cylinder_reactor.py
@@ -47,11 +47,15 @@ class TestCylinderReactor(unittest.TestCase):
 
         os.system("rm test_reactor.brep")
 
-        self.test_reactor.export_brep(filename='test_reactor.brep')
+        self.test_reactor.export_brep(filename='merged.brep', merged=True)
+        self.test_reactor.export_brep(filename='not_merged.brep', merged=False)
 
-        assert Path("test_reactor.brep").exists() is True
+        assert Path("merged.brep").exists() is True
+        assert Path("not_merged.brep").exists() is True
+        assert Path("not_merged.brep").stat().st_size > Path("merged.brep").stat().st_size
 
-        os.system("rm test_reactor.brep")
+        os.system("rm merged.brep")
+        os.system("rm not_merged.brep")
 
     def test_export_brep_without_extention(self):
         """Exports a brep file without the extention and checks that the

--- a/tests/test_parametric_reactors/test_cylinder_reactor.py
+++ b/tests/test_parametric_reactors/test_cylinder_reactor.py
@@ -47,8 +47,8 @@ class TestCylinderReactor(unittest.TestCase):
 
         os.system("rm test_reactor.brep")
 
-        self.test_reactor.export_brep(filename='merged.brep', merged=True)
-        self.test_reactor.export_brep(filename='not_merged.brep', merged=False)
+        self.test_reactor.export_brep(filename='merged.brep', merge=True)
+        self.test_reactor.export_brep(filename='not_merged.brep', merge=False)
 
         assert Path("merged.brep").exists() is True
         assert Path("not_merged.brep").exists() is True


### PR DESCRIPTION
## Proposed changes

As discussed in the cadquery issue https://github.com/CadQuery/cadquery/issues/449 it looks like is possible to merge surfaces in a brep file. This PR adds a ```merge``` option to the ```Reactor.export_brep()``` to test out the feature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
