### PR TITLE
Adding check for name none

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -312,6 +312,12 @@ class Reactor:
             return [filename]
 
         if filename is None:
+            for name in self.name:
+                if name == None:
+                    msg = ("Shape.name is None and therefore it can't be used "
+                        "to name a stp file. Try setting Shape.name for all "
+                        "shapes in the reactor")
+                    raise ValueError()
             filename = [f"{name}.stp" for name in self.name]
 
         # exports the reactor solid as a separate stp files

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -314,8 +314,8 @@ class Reactor:
         if filename is None:
             if None in self.name:
                 msg = ("Shape.name is None and therefore it can't be used "
-                    "to name a stp file. Try setting Shape.name for all "
-                    "shapes in the reactor")
+                       "to name a stp file. Try setting Shape.name for all "
+                       "shapes in the reactor")
                 raise ValueError(msg)
             filename = [f"{name}.stp" for name in self.name]
 
@@ -429,8 +429,8 @@ class Reactor:
         if filename is None:
             if None in self.name:
                 msg = ("Shape.name is None and therefore it can't be used "
-                    "to name a stl file. Try setting Shape.name for all "
-                    "shapes in the reactor")
+                       "to name a stl file. Try setting Shape.name for all "
+                       "shapes in the reactor")
                 raise ValueError()
             filename = [f"{name}.stl" for name in self.name]
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -312,12 +312,11 @@ class Reactor:
             return [filename]
 
         if filename is None:
-            for name in self.name:
-                if name == None:
-                    msg = ("Shape.name is None and therefore it can't be used "
-                        "to name a stp file. Try setting Shape.name for all "
-                        "shapes in the reactor")
-                    raise ValueError()
+            if None in self.name:
+                msg = ("Shape.name is None and therefore it can't be used "
+                    "to name a stp file. Try setting Shape.name for all "
+                    "shapes in the reactor")
+                raise ValueError()
             filename = [f"{name}.stp" for name in self.name]
 
         # exports the reactor solid as a separate stp files
@@ -428,6 +427,11 @@ class Reactor:
             return str(path_filename)
 
         if filename is None:
+            if None in self.name:
+                msg = ("Shape.name is None and therefore it can't be used "
+                    "to name a stl file. Try setting Shape.name for all "
+                    "shapes in the reactor")
+                raise ValueError()
             filename = [f"{name}.stl" for name in self.name]
 
         # exports the reactor solid as a separate stl files

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -316,7 +316,7 @@ class Reactor:
                 msg = ("Shape.name is None and therefore it can't be used "
                     "to name a stp file. Try setting Shape.name for all "
                     "shapes in the reactor")
-                raise ValueError()
+                raise ValueError(msg)
             filename = [f"{name}.stp" for name in self.name]
 
         # exports the reactor solid as a separate stp files

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -37,8 +37,21 @@ class TestReactor(unittest.TestCase):
         self.test_reactor_3 = paramak.Reactor(
             [self.test_shape, test_shape_3])
 
+    def test_reactor_export_stp_with_name_set_to_none(self):
+        """Exports the reactor as separate files and as a single file"""
+
+        def incorrect_name():
+            self.test_shape.name = None
+
+            test_reactor = paramak.Reactor([self.test_shape])
+
+            self.test_reactor.export_stp()
+
+        self.assertRaises(ValueError, incorrect_name)
+
+
     def test_reactor_export_stp(self):
-        """Exports the reactor as seperate files and as a single file"""
+        """Exports the reactor as separate files and as a single file"""
         os.system('rm *.stp')
         self.test_reactor_2.export_stp(
             filename=['RotateStraightShape.stp', 'ExtrudeStraightShape.stp']

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -49,7 +49,6 @@ class TestReactor(unittest.TestCase):
 
         self.assertRaises(ValueError, incorrect_name)
 
-
     def test_reactor_export_stp(self):
         """Exports the reactor as separate files and as a single file"""
         os.system('rm *.stp')

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -298,6 +298,18 @@ class TestReactor(unittest.TestCase):
         assert Path("test_reactor/test_shape.stl").exists() is True
         os.system("rm test_reactor/test_shape.stl")
 
+    def test_reactor_export_stl_with_name_set_to_none(self):
+        """Exports the reactor as separate files and as a single file"""
+
+        def incorrect_name():
+            self.test_shape.name = None
+
+            test_reactor = paramak.Reactor([self.test_shape])
+
+            self.test_reactor.export_stl()
+
+        self.assertRaises(ValueError, incorrect_name)
+
     def test_exported_svg_files_exist(self):
         """Creates a Reactor object with one shape and checks that a svg file
         of the reactor can be exported to a specified location using the

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -43,7 +43,7 @@ class TestReactor(unittest.TestCase):
         def incorrect_name():
             self.test_shape.name = None
 
-            test_reactor = paramak.Reactor([self.test_shape])
+            paramak.Reactor([self.test_shape])
 
             self.test_reactor.export_stp()
 
@@ -303,7 +303,7 @@ class TestReactor(unittest.TestCase):
         def incorrect_name():
             self.test_shape.name = None
 
-            test_reactor = paramak.Reactor([self.test_shape])
+            paramak.Reactor([self.test_shape])
 
             self.test_reactor.export_stl()
 


### PR DESCRIPTION
## Proposed changes

stp files were being exported with the name as None and saved as None.stp.

This PR adds a check when exporting stp and slt files using the Shape.name. Checks that the Shape.name is not None.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
