### PR TITLE
Adding part properties for brep to h5m

### DIFF
--- a/paramak/parametric_shapes/extruded_mixed_shape.py
+++ b/paramak/parametric_shapes/extruded_mixed_shape.py
@@ -83,7 +83,7 @@ class ExtrudeMixedShape(Shape):
 
         self.wire = wire
 
-        solid = wire.extrude(distance=extrusion_distance, both=self.extrude_both)
+        solid = wire.extrude(until=extrusion_distance, both=self.extrude_both)
 
         # filleting rectangular port cutter edges
         # must be done before azimuthal placement

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -59,8 +59,34 @@ class Reactor:
 
         self.graveyard = None
         self.solid = None
-
+        self.part_properties = None
         self.reactor_hash_value = None
+
+    @property
+    def part_properties(self):
+        properties = {}
+        for part in self.shapes_and_components:
+            part_bb = part.solid.val().BoundingBox()
+            part_center = part.solid.val().Center()
+            properties[part.name]= {
+                'volume':part.solid.val().Volume(),
+                'center':(part_center.x, part_center.y, part_center.z),
+                'bounding_box':((
+                    part_bb.xmin,
+                    part_bb.ymin,
+                    part_bb.zmin
+                ),(
+                    part_bb.xmax,
+                    part_bb.ymax,
+                    part_bb.zmax
+                ))
+            }
+        self._part_properties = properties
+        return self._part_properties
+
+    @part_properties.setter
+    def part_properties(self, value):
+        self._part_properties = value
 
     @property
     def input_variables(self):

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -68,18 +68,13 @@ class Reactor:
         for part in self.shapes_and_components:
             part_bb = part.solid.val().BoundingBox()
             part_center = part.solid.val().Center()
-            properties[part.name]= {
-                'volume':part.solid.val().Volume(),
-                'center':(part_center.x, part_center.y, part_center.z),
-                'bounding_box':((
-                    part_bb.xmin,
-                    part_bb.ymin,
-                    part_bb.zmin
-                ),(
-                    part_bb.xmax,
-                    part_bb.ymax,
-                    part_bb.zmax
-                ))
+            properties[part.name] = {
+                "volume": part.solid.val().Volume(),
+                "center": (part_center.x, part_center.y, part_center.z),
+                "bounding_box": (
+                    (part_bb.xmin, part_bb.ymin, part_bb.zmin),
+                    (part_bb.xmax, part_bb.ymax, part_bb.zmax),
+                ),
             }
         self._part_properties = properties
         return self._part_properties


### PR DESCRIPTION
## Proposed changes

adds a ```part_properties``` method to the ```Reactor``` class for use with the brep_part_finder package

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
