### PR TITLE
avoiding builds tools: method copy .git instead of bind

### DIFF
--- a/.github/workflows/ci_with_docker_build.yml
+++ b/.github/workflows/ci_with_docker_build.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build and test with Docker
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           docker build -t paramak --build-arg cq_version=2.1 .
           docker run --rm paramak  /bin/bash -c "bash run_tests.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,9 @@ COPY pyproject.toml pyproject.toml
 COPY tests tests/
 COPY README.md README.md
 COPY LICENSE.txt LICENSE.txt
+COPY .git .git/
 
-RUN --mount=source=.git,target=.git,type=bind pip install --no-cache-dir -e .[tests,docs]
+RUN pip install --no-cache-dir -e .[tests,docs]
 
 # this helps prevent the kernal failing
 RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh


### PR DESCRIPTION
## Proposed changes

Trying to remove the need for BuildKit so that the dockerfile can be built by windows users.

This is just one option but this appears simple as it copies over the .git folder and then the ```pip install .``` works

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests
