### PR TITLE
avoiding builds tools: method get version number from CI

### DIFF
--- a/.github/workflows/ci_with_docker_build.yml
+++ b/.github/workflows/ci_with_docker_build.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build and test with Docker
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           docker build -t paramak --build-arg cq_version=2.1 .
           docker run --rm paramak  /bin/bash -c "bash run_tests.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ FROM continuumio/miniconda3:4.9.2 as dependencies
 
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=2.1
-ARG paramak_version=develop
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
@@ -57,6 +56,8 @@ WORKDIR /home/paramak
 
 
 FROM dependencies as final
+
+ARG paramak_version=develop
 
 COPY run_tests.sh run_tests.sh
 COPY paramak paramak/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,15 @@
 #
 # There are build args availalbe for specifying the:
 # - cq_version
-#   The version of CadQuery to use master or 2.1 
+#   The version of CadQuery to use master or 2.1
 #   Default is 2.1
 #   Options: [master, 2, 2.1]
+#
+# - paramak_version
+#   The version number applied to the paramak. The CI finds this version number
+#   from the release tag.
+#   Default is develop
+#   Options: version number with three numbers separated by . for example 0.7.1
 #
 # Example builds:
 # Building using the defaults (cq_version 2.1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM continuumio/miniconda3:4.9.2 as dependencies
 
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=2.1
-
+ARG paramak_version=develop
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
@@ -68,7 +68,7 @@ COPY tests tests/
 COPY README.md README.md
 COPY LICENSE.txt LICENSE.txt
 
-RUN --mount=source=.git,target=.git,type=bind pip install --no-cache-dir -e .[tests,docs]
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK=${paramak_version} pip install -e .[tests,docs]
 
 # this helps prevent the kernal failing
 RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,9 +8,12 @@ def test_version():
     # Ensure it is given as a string
     assert isinstance(version, str)
     # Ensure is has at least three parts -- major, minor and patch -- separated by '.'
-    version_bits = version.split(".")
-    assert len(version_bits) >= 3
-    # Ensure each of the first three parts is convertable to int
-    # (The fourth part, if it exists, may be a development version)
-    for bit in version_bits[:3]:
-        assert bit.isdigit()
+    
+    # develop is used as the default version name in the dockerfile
+    if version != 'develop':
+        version_bits = version.split(".")
+        assert len(version_bits) >= 3
+        # Ensure each of the first three parts is convertable to int
+        # (The fourth part, if it exists, may be a development version)
+        for bit in version_bits[:3]:
+            assert bit.isdigit()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,9 +8,9 @@ def test_version():
     # Ensure it is given as a string
     assert isinstance(version, str)
     # Ensure is has at least three parts -- major, minor and patch -- separated by '.'
-    
+
     # develop is used as the default version name in the dockerfile
-    if version != 'develop':
+    if version != "develop":
         version_bits = version.split(".")
         assert len(version_bits) >= 3
         # Ensure each of the first three parts is convertable to int


### PR DESCRIPTION
## Proposed changes

This PR removes the need for --bind and BuildKit by passing in the paramak version number via the build-args. Also removes the need to copy the .git folder

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests
