### PR TITLE
Avoid Docker BuiltKit by installing from wheel

### DIFF
--- a/.github/workflows/ci_with_docker_build.yml
+++ b/.github/workflows/ci_with_docker_build.yml
@@ -22,9 +22,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build and test with Docker
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Build wheel
         run: |
-          docker build -t paramak --build-arg cq_version=2.1 .
+          python3 -m pip install --upgrade pip
+          python3 -m pip install build
+          python3 -m build .
+
+      - name: Get wheel name
+        run: |
+          echo "WHEEL_NAME=$(ls -t dist/*.whl | head -n 1)" >> $GITHUB_ENV
+
+      - name: Build and test with Docker
+        run: |
+          docker build -t paramak --build-arg cq_version=2.1 --build-arg wheel=$WHEEL_NAME .
           docker run --rm paramak  /bin/bash -c "bash run_tests.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,6 @@ FROM continuumio/miniconda3:4.9.2 as dependencies
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=2.1
 
-# Docker must be passed "wheel" as a --build-arg
-# Call `python -m build .` in the root directory, then check the `dist/` directory to find the wheel
-ARG wheel
-
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -61,12 +57,16 @@ WORKDIR /home/paramak
 
 FROM dependencies as final
 
+# Docker must be passed "wheel" as a --build-arg
+# Call `python -m build .` in the root directory, then check the `dist/` directory to find the wheel
+ARG wheel
+
 COPY examples examples/
 COPY tests tests/
 COPY run_tests.sh run_tests.sh
 COPY $wheel $wheel
 
-RUN pip install "$wheel"[tests]
+RUN pip install $wheel[tests]
 
 # this helps prevent the kernal failing
 RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ FROM continuumio/miniconda3:4.9.2 as dependencies
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=2.1
 
+# Docker must be passed "wheel" as a --build-arg
+# Call `python -m build .` in the root directory, then check the `dist/` directory to find the wheel
+ARG wheel
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
@@ -58,17 +61,11 @@ WORKDIR /home/paramak
 
 FROM dependencies as final
 
-COPY run_tests.sh run_tests.sh
-COPY paramak paramak/
 COPY examples examples/
-COPY setup.py setup.py
-COPY setup.cfg setup.cfg
-COPY pyproject.toml pyproject.toml
-COPY tests tests/
-COPY README.md README.md
-COPY LICENSE.txt LICENSE.txt
+COPY run_tests.sh run_tests.sh
+COPY $wheel $wheel
 
-RUN --mount=source=.git,target=.git,type=bind pip install --no-cache-dir -e .[tests,docs]
+RUN pip install ${wheel}[tests]
 
 # this helps prevent the kernal failing
 RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ WORKDIR /home/paramak
 FROM dependencies as final
 
 COPY examples examples/
+COPY tests tests/
 COPY run_tests.sh run_tests.sh
 COPY $wheel $wheel
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY tests tests/
 COPY run_tests.sh run_tests.sh
 COPY $wheel $wheel
 
-RUN pip install ${wheel}[tests]
+RUN pip install "$wheel"[tests]
 
 # this helps prevent the kernal failing
 RUN echo "#!/bin/bash\n\njupyter lab --notebook-dir=/home/paramak/examples --port=8888 --no-browser --ip=0.0.0.0 --allow-root" >> docker-cmd.sh


### PR DESCRIPTION
## Proposed changes

Another potential way to avoid BuildKit, similar to https://github.com/fusion-energy/paramak/pull/159 and https://github.com/fusion-energy/paramak/pull/158, is to build a Python Wheel, copy only that and unit test requirements into the container, and install from there. The primary downside of this approach (if it works) is that the user must now pass the filename of a Python wheel as a --build-arg to docker (it may be possible to grab this from within the Dockerfile, but I'm not familiar enough with Docker ARGs to confirm). The upside is that it should result in a very lightweight container and solve the version inference problem.

This will require additional changes to `docker-publish.yml` before it's ready to merge, though I'll need to do some further reading before making those changes.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
