### PR TITLE
Ignore __init__.py imports with flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,6 @@ docs =
     sphinx_rtd_theme
     sphinx_autodoc_typehints
     sphinxcadquery
+
+[flake8]
+per-file-ignores = __init__.py:F401


### PR DESCRIPTION
## Proposed changes

Adds a few lines to setup.cfg to inform flake8 to ignore convenience imports from __init__.py. 

Closes https://github.com/fusion-energy/paramak/issues/134

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
