### PR TITLE
pinned pyparsing ~= 2.4.7

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "paramak" %}
-{% set data = load_setup_py_data() %}
+{% set version = "0.6.6" %}
 
 package:
   name: "{{ name|lower }}"
-  version: {{ data.get('version') }}
+  version: {{ version }}
 
 source:
   path: ..

--- a/conda_build.sh
+++ b/conda_build.sh
@@ -21,14 +21,6 @@ mkdir -p /tmp/conda-build
 rm -rf /tmp/conda-build
 
 
-# VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-VERSION=0.6.4
-PLACEHOLDER='version="develop"'
-VERSION_FILE='setup.py'
-# Grep checks that the placeholder is in the file. If grep doesn't find
-# the placeholder then it exits with exit code 1 and github actions fails.
-grep "$PLACEHOLDER" "$VERSION_FILE"
-sed -i "s@$PLACEHOLDER@version=\"${VERSION}\"@g" "$VERSION_FILE"
 
 conda-build conda/ -c cadquery -c conda-forge --croot /tmp/conda-build 
 
@@ -48,5 +40,3 @@ do
 done
 
 anaconda upload -f /tmp/conda-build/*/*.tar.bz2
-
-sed -i "s@version=\"${VERSION}\"@$PLACEHOLDER@g" "$VERSION_FILE"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,10 +20,10 @@ The Paramak python package allows rapid production of 3D CAD models of fusion
 reactors. The purpose of the Paramak is to provide geometry for parametric
 studies in a variety of CAD formats including STL, STP and Brep files.
 
-adQuery functions provide the majority of the features, and incorporating
+CadQuery functions provide the majority of the features, and incorporating
 additional capabilities is straightforward for developers with Python knowledge.
 
-Contributions are welcome. C
+Contributions are welcome.
 
 .. raw:: html
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -76,6 +76,22 @@ Then pip install the Paramak.
 Now you should be ready to import paramak from your new python environment.
 
 
+Optional Jupyter-CadQuery install
+---------------------------------
+
+Jupyter-Cadquery is an extension to CadQuery that allows objects to be
+rendered in JupyterLab. This can improve the visualization experience for
+Paramak users running Jupyter.
+
+ `Jupyter-Cadquery GitHub page <https://github.com/bernhard-42/jupyter-cadquery>`_
+
+Terminal command to install Jupyter-Cadquery
+
+.. code-block:: bash
+
+   pip install jupyter-cadquery
+
+
 Optional neutronics install
 ---------------------------
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,6 +3,14 @@ Installation
 ============
 
 
+
+.. raw:: html
+
+      <iframe width="280" height="157" src="https://www.youtube.com/embed/29nXEpAaELE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+      <iframe width="280" height="157" src="https://www.youtube.com/embed/HJfOrDM9Avo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
 Prerequisites
 -------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   - python=3.8
-  - pyparsing>=2.1.9
+  - pyparsing~=2.4.7
   - cadquery=2.1
   - pytest
   - plotly

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 
 dependencies:
   - python=3.8
+  - pyparsing>=2.1.9
   - cadquery=2.1
   - pytest
   - plotly
@@ -14,7 +15,6 @@ dependencies:
   - matplotlib
   - pillow
   - pip:
-      - pyparsing==2.4.7
       - sympy
       - plasmaboundaries
       - sphinx-autodoc-typehints

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ project_urls =
 packages = find:
 python_requires= >=3.6
 install_requires=
-    pyparsing>=2.1.9
+    pyparsing ~= 2.4.7
     plotly >= 5.1.0
     scipy >= 1.7.0
     sympy >= 1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ project_urls =
 packages = find:
 python_requires= >=3.6
 install_requires=
+    pyparsing>=2.1.9
     plotly >= 5.1.0
     scipy >= 1.7.0
     sympy >= 1.8
@@ -44,7 +45,6 @@ tests =
     nbconvert>=6.1.0
 docs = 
     sphinx >= 4.1.2
-    pyparsing ~= 2.4.7
     sphinx_rtd_theme
     sphinx_autodoc_typehints
     sphinxcadquery

--- a/tests/test_parametric_shapes/test_extrude_straight_shape.py
+++ b/tests/test_parametric_shapes/test_extrude_straight_shape.py
@@ -30,7 +30,7 @@ class TestExtrudeStraightShape(unittest.TestCase):
         )
 
         assert isinstance(test_shape_2.workplane, Plane)
-        assert pytest.approx(test_shape_2.volume, self.test_shape.volume)
+        assert pytest.approx(test_shape_2.volume) == self.test_shape.volume
 
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeStraightShape are

--- a/tests/test_parametric_shapes/test_extrude_straight_shape.py
+++ b/tests/test_parametric_shapes/test_extrude_straight_shape.py
@@ -30,7 +30,7 @@ class TestExtrudeStraightShape(unittest.TestCase):
         )
 
         assert isinstance(test_shape_2.workplane, Plane)
-        assert pytest.approx(test_shape_2.volume) == self.test_shape.volume
+        assert pytest.approx(test_shape_2.volume()) == self.test_shape.volume()
 
     def test_default_parameters(self):
         """Checks that the default parameters of an ExtrudeStraightShape are

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -395,11 +395,11 @@ class TestReactor(unittest.TestCase):
         test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
         test_shape.rotation_angle = 360
         test_reactor = paramak.Reactor([test_shape])
-        assert pytest.approx(test_reactor.largest_dimension, rel=0.1 == 20)
+        assert pytest.approx(test_reactor.largest_dimension, rel=0.1) == 20
         test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (30, 20)])
         test_shape.rotation_angle = 360
         test_reactor = paramak.Reactor([test_shape])
-        assert pytest.approx(test_reactor.largest_dimension, rel=0.1 == 30)
+        assert pytest.approx(test_reactor.largest_dimension, rel=0.1) == 30
 
     def test_shapes_and_components(self):
         """Attempts to make a reactor with a single shape instead of a list of
@@ -520,7 +520,7 @@ class TestReactor(unittest.TestCase):
         vol_2 = self.test_reactor_3.volume(split_compounds=True)[1][1]
         assert vol_1 == vol_2
         vol_3 = self.test_reactor_3.volume(split_compounds=False)[1]
-        assert pytest.approx(vol_3, vol_1 + vol_2)
+        assert pytest.approx(vol_3) == vol_1 + vol_2
 
     def test_reactor_names(self):
         "checks that the names attribute returns the expected results"


### PR DESCRIPTION
## Proposed changes

pins the version of pyparsing to the same version that cadquery is pinning to.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
