### PR TITLE
removed packages that are brought in already

### DIFF
--- a/.github/workflows/anaconda-publish-develop.yml
+++ b/.github/workflows/anaconda-publish-develop.yml
@@ -8,23 +8,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # This container includes libgl1-mesa-glx, anaconda-client and conda-build
+    # https://github.com/shimwell/miniconda3_docker_image/blob/main/Dockerfile
+    container: ghcr.io/shimwell/miniconda
+
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
       - name: Set up conda
         run: |
-            conda install -y anaconda-client conda-build
-            conda config --set anaconda_upload yes
+            conda config --set anaconda_upload no
       - name: Build and publish to conda
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
             conda build conda_dev -c fusion-energy -c cadquery -c conda-forge --config-file conda_dev/conda_build_config.yaml
+            conda convert /opt/conda/conda-bld/linux-64/*.tar.bz2 --platform osx-64
+            anaconda upload -f /opt/conda/conda-bld/*/*.tar.bz2
 
 # this action does not currently convert to windows or OSX

--- a/.github/workflows/anaconda-publish-develop.yml
+++ b/.github/workflows/anaconda-publish-develop.yml
@@ -27,4 +27,4 @@ jobs:
             conda convert /opt/conda/conda-bld/linux-64/*.tar.bz2 --platform osx-64
             anaconda upload -f /opt/conda/conda-bld/*/*.tar.bz2
 
-# this action does not currently convert to windows or OSX
+# Note this action does not currently convert to windows as it requires moab

--- a/conda_dev/meta.yaml
+++ b/conda_dev/meta.yaml
@@ -17,14 +17,11 @@ requirements:
     - python {{ python }}
     - setuptools
   run:
-    - cadquery==master
+    - python
     - matplotlib
     - mpmath
-    - numpy
     - plasmaboundaries
     - plotly
-    - pytest-cov
-    - python
     - scipy
     - sympy
     - nbformat
@@ -32,6 +29,7 @@ requirements:
     - ipywidgets
     - brep_part_finder
     - brep_to_h5m [not win]
+    # - cadquery==master is included in brep_part_finder
     # - gmsh is included in brep_to_h5m
     # - moab is included in brep_to_h5m
     # - stl_to_h5m is included in brep_to_h5m
@@ -49,14 +47,15 @@ test:
     - dagmc_h5m_file_inspector [not win]
   source_files:
     - tests/
-    # - tests_examples/  # TODO include if cadquery_jupyter gets a conda install
     - tests_h5m/
     - examples/
+    # - tests_examples/  # TODO include if cadquery_jupyter gets a conda install
+    # - tests_show/  # TODO include if cadquery_jupyter gets a conda install
   commands:
     - pytest -v tests
     - pytest -v tests_h5m
     # - pytest -v tests_examples  # TODO include if cadquery_jupyter gets a conda install
-    # - tests_show  # TODO include if cadquery_jupyter gets a conda install
+    # - pytest -v tests_show  # TODO include if cadquery_jupyter gets a conda install
 
 about:
   home: "https://github.com/fusion-energy/paramak"

--- a/conda_dev/meta.yaml
+++ b/conda_dev/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python {{ python }}
     - setuptools
   run:
-    - cadquery
+    - cadquery==master
     - matplotlib
     - mpmath
     - numpy
@@ -30,10 +30,11 @@ requirements:
     - nbformat
     - nbconvert
     - ipywidgets
-    - brep_to_h5m
     - brep_part_finder
-    - gmsh [not win]
-    - moab [not win]
+    - brep_to_h5m [not win]
+    # - gmsh is included in brep_to_h5m
+    # - moab is included in brep_to_h5m
+    # - stl_to_h5m is included in brep_to_h5m
     # - jupyter-cadquery not available on conda
 
 test:


### PR DESCRIPTION
## Proposed changes

This updates the conda build for the ```paramak_develop``` version of paramak

This is a version that makes use of the current cadquery master branch and has a few experimental features

One feature is the ability to export the geometry as a dagmc h5m file

This conda build is working locally so hopefully it will work on the github action



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
