### PR TITLE
Changes to work with jupyter cadquery v3.0.0

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -185,15 +185,15 @@ class Reactor:
 
         return all_names
 
-    def show(self, default_edgecolor: Tuple[float, float, float] = (0, 0, 0)):
+    def show(self, **kwargs):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
         show from jupyter_cadquery.cadquery and returns show(Reactor.solid)
 
         Args:
-            default_edgecolor: the color to use for the edges, passed to
-                jupyter_cadquery.cadquery show. Tuple of three values expected
-                individual values in the tuple should be floats between 0. and
-                1.
+            kwargs: keyword arguments passed to jupyter-cadquery show()
+                function. See https://github.com/bernhard-42/jupyter-cadquery#usage
+                for more details on acceptable keywords
+
 
         Returns:
             jupyter_cadquery.cadquery.show object
@@ -218,7 +218,6 @@ class Reactor:
                 name = shape_or_compound.name
 
             scaled_color = [int(i * 255) for i in shape_or_compound.color[0:3]]
-            scaled_edge_color = [int(i * 255) for i in default_edgecolor[0:3]]
             if isinstance(
                 shape_or_compound.solid,
                 (cq.occ_impl.shapes.Shape, cq.occ_impl.shapes.Compound),
@@ -234,7 +233,7 @@ class Reactor:
                     )
                 )
 
-        return show(PartGroup(parts), default_edgecolor=scaled_edge_color)
+        return show(PartGroup(parts), **kwargs)
 
     def export_dagmc_h5m(
         self,

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -825,12 +825,16 @@ class Reactor:
     def export_html_3d(
         self,
         filename: Optional[str] = "reactor_3d.html",
+        **kwargs
     ) -> Optional[str]:
         """Saves an interactive 3d html view of the Reactor to a html file.
 
         Args:
             filename: the filename used to save the html graph. Defaults to
                 reactor_3d.html
+            kwargs: keyword arguments passed to jupyter-cadquery show()
+                function. See https://github.com/bernhard-42/jupyter-cadquery#usage
+                for more details on acceptable keywords
 
         Returns:
             str: filename of the created html file
@@ -838,13 +842,9 @@ class Reactor:
 
         view = self.show()
 
-        # ipywidgets is installed along with jupyter_cadquery
-        from ipywidgets.embed import embed_minimal_html
+        view = self.show(**kwargs)
 
-        if view is None:
-            return None
-
-        embed_minimal_html(filename, views=[view.cq_view.renderer], title="Renderer")
+        view.export_html(filename)
 
         return filename
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -840,8 +840,6 @@ class Reactor:
             str: filename of the created html file
         """
 
-        view = self.show()
-
         view = self.show(**kwargs)
 
         view.export_html(filename)

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -187,7 +187,7 @@ class Reactor:
 
     def show(self, **kwargs):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
-        show from jupyter_cadquery.cadquery and returns show(Reactor.solid)
+        show from jupyter_cadquery and returns show(Reactor.solid, kwargs)
 
         Args:
             kwargs: keyword arguments passed to jupyter-cadquery show()
@@ -196,11 +196,11 @@ class Reactor:
 
 
         Returns:
-            jupyter_cadquery.cadquery.show object
+            jupyter_cadquery show object
         """
 
         try:
-            from jupyter_cadquery.cadquery import Part, PartGroup, show
+            from jupyter_cadquery import Part, PartGroup, show
         except ImportError:
             msg = (
                 "To use Reactor.show() you must install jupyter_cadquery. To"

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -540,15 +540,14 @@ class Shape:
         result = importers.importStep(filename)
         self.solid = result
 
-    def show(self, default_edgecolor: Tuple[float, float, float] = (0, 0, 0)):
+    def show(self, **kwargs):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
         show from jupyter_cadquery.cadquery and returns show(Shape.solid)
 
         Args:
-            default_edgecolor: the color to use for the edges, passed to
-                jupyter_cadquery.cadquery show. Tuple of three values expected
-                individual values in the tuple should be floats between 0. and
-                1.
+            kwargs: keyword arguments passed to jupyter-cadquery show()
+                function. See https://github.com/bernhard-42/jupyter-cadquery#usage
+                for more details on acceptable keywords
 
         Returns:
             jupyter_cadquery.cadquery.show object
@@ -571,7 +570,6 @@ class Shape:
             name = self.name
 
         scaled_color = [int(i * 255) for i in self.color[0:3]]
-        scaled_edge_color = [int(i * 255) for i in default_edgecolor[0:3]]
         if isinstance(self.solid, (shapes.Shape, shapes.Compound)):
             for i, solid in enumerate(self.solid.Solids()):
                 parts.append(
@@ -587,7 +585,7 @@ class Shape:
                 )
             )
 
-        return show(PartGroup(parts), default_edgecolor=scaled_edge_color)
+        return show(PartGroup(parts), **kwargs)
 
     def create_solid(self) -> Workplane:
         solid = None

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -542,7 +542,7 @@ class Shape:
 
     def show(self, **kwargs):
         """Shows / renders the CadQuery the 3d object in Jupyter Lab. Imports
-        show from jupyter_cadquery.cadquery and returns show(Shape.solid)
+        show from jupyter_cadquery and returns show(Shape.solid, kwargs)
 
         Args:
             kwargs: keyword arguments passed to jupyter-cadquery show()
@@ -550,11 +550,11 @@ class Shape:
                 for more details on acceptable keywords
 
         Returns:
-            jupyter_cadquery.cadquery.show object
+            jupyter_cadquery show object
         """
 
         try:
-            from jupyter_cadquery.cadquery import Part, PartGroup, show
+            from jupyter_cadquery import Part, PartGroup, show
         except ImportError:
             msg = (
                 "To use Shape.show() you must install jupyter_cadquery. To"

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -1035,26 +1035,24 @@ class Shape:
     def export_html_3d(
         self,
         filename: Optional[str] = "shape_3d.html",
+        **kwargs
     ):
         """Saves an interactive 3d html view of the Shape to a html file.
 
         Args:
             filename: the filename used to save the html graph. Defaults to
                 shape_3d.html
+            kwargs: keyword arguments passed to jupyter-cadquery show()
+                function. See https://github.com/bernhard-42/jupyter-cadquery#usage
+                for more details on acceptable keywords
 
         Returns:
             str: filename of the created html file
         """
 
-        view = self.show()
+        view = self.show(**kwargs)
 
-        # ipywidgets is installed along with jupyter_cadquery
-        from ipywidgets.embed import embed_minimal_html
-
-        if view is None:
-            return None
-
-        embed_minimal_html(filename, views=[view.cq_view.renderer], title="Renderer")
+        view.export_html(filename)
 
         return filename
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires=
     matplotlib >= 3.4.2
     plasmaboundaries >= 0.1.8
     jupyter-client < 7
-    jupyter-cadquery >= 2.2.0
+    jupyter-cadquery >= 3.0.0
     brep_part_finder >= 0.3.16
     brep_to_h5m >= 0.2.8
 


### PR DESCRIPTION
## Proposed changes

Jupyter-Cadquery was recently updated and looks even better than before. Congrats to @bernhard-42 for continuing to develop this nice software. It is a great package that we should certainly try to keep making use of. A few changes to the import statement and show method are needed to work with the new v3.0.0 api for jupyter-cadquery

This PR is still not quite working in the dockerfile and I'm getting a error when trying to display the 3d model using jupyter-cadquery in jupyter lab.

So this PR is a working progress but I hope to get this working soon, I'm just in the process of reformatting my computer so hopefully I shall be up and running with a new system soon
```
Error displaying widget

<cad_viewer_widget.widget.CadViewer at 0x7f1e4ab8eaf0>
```

and other errors
```
>       embed_minimal_html(filename, views=[view.cq_view.renderer], title="Renderer")
E       AttributeError: 'CadViewer' object has no attribute 'cq_view'
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
the variable name ```default_edgecolor``` is now ```default_edge_color```
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests
