### PR TITLE
accepting azimuth_start_angle

### DIFF
--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -34,6 +34,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         number_of_coils: int,
         with_inner_leg: bool = True,
         color: Tuple[float, float, float, Optional[float]] = (0.0, 0.0, 1.0),
+        azimuth_start_angle: float = 0,
         **kwargs
     ) -> None:
 
@@ -45,6 +46,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         self.distance = distance
         self.number_of_coils = number_of_coils
         self.with_inner_leg = with_inner_leg
+        self.azimuth_start_angle = azimuth_start_angle
 
     @property
     def azimuth_placement_angle(self):
@@ -112,7 +114,7 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         """Calculates the azimuth placement angles based on the number of tf
         coils"""
 
-        angles = list(np.linspace(0, 360, self.number_of_coils, endpoint=False))
+        angles = list(np.linspace(self.azimuth_start_angle, 360+self.azimuth_start_angle, self.number_of_coils, endpoint=False))
 
         self.azimuth_placement_angle = angles
 

--- a/paramak/parametric_components/toroidal_field_coil_rectangle.py
+++ b/paramak/parametric_components/toroidal_field_coil_rectangle.py
@@ -114,7 +114,14 @@ class ToroidalFieldCoilRectangle(ExtrudeStraightShape):
         """Calculates the azimuth placement angles based on the number of tf
         coils"""
 
-        angles = list(np.linspace(self.azimuth_start_angle, 360+self.azimuth_start_angle, self.number_of_coils, endpoint=False))
+        angles = list(
+            np.linspace(
+                self.azimuth_start_angle,
+                360 + self.azimuth_start_angle,
+                self.number_of_coils,
+                endpoint=False,
+            )
+        )
 
         self.azimuth_placement_angle = angles
 


### PR DESCRIPTION
## Proposed changes

As requested by a user the TF magnets should have a controllable position for the start of the placements.

While the placements are calculated automatically (360 / number of magnets) it is desirable to be able to specify a starting rotation angle.

Users can now specify ```azimuth_start_angle``` to start at a different location.

This allows offsets like the image
![Screenshot from 2022-03-03 21-03-12](https://user-images.githubusercontent.com/8583900/156653496-8231e171-5bf5-4310-817d-902f1f5ae1d8.png)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
