### PR TITLE
Adding circlar ports with flange gap option

### DIFF
--- a/docs/source/API-Reference.rst
+++ b/docs/source/API-Reference.rst
@@ -1041,8 +1041,55 @@ PoloidalFieldCoilCaseSetFC()
    :show-inheritance:
 
 
-Port Cutters
-------------
+Ports
+-----
+
+CircularPort()
+^^^^^^^^^^^^^^
+
+.. cadquery::
+   :select: cadquery_object
+   :gridsize: 0
+
+   component = paramak.CircularPort(
+      color = (0,1,0),
+      rotation_angle=45,
+      blank_flange_thickness=4,
+      flange_thickness=10,
+      wall_thickness=2,
+      distance = 50,
+   )
+
+   cadquery_object = my_component.solid
+
+
+.. cadquery::
+   :select: cadquery_object
+   :gridsize: 0
+
+   component = paramak.CircularPort(
+      inner_radius = 20,
+      azimuth_placement_angle= [0.,  30.,  60.,  90., 120., 150., 180., 210., 240., 270., 300., 330.],
+         color = (0,1,0),
+         rotation_angle=180,
+         blank_flange_thickness=4,
+         flange_thickness=10,
+         wall_thickness=2,
+         distance = 50,
+         flange_gap=0
+      )
+
+   cadquery_object = my_component.solid
+
+|CircularPortRotatedsvg|
+
+.. |CircularPortRotatedsvg| image:: https://user-images.githubusercontent.com/8583900/159140637-ee6c72f8-1094-4261-90a2-b137b2777c92.png
+    :width: 380px
+
+.. automodule:: paramak.parametric_components.circular_port
+   :members:
+   :show-inheritance:
+
 
 PortCutterRotated()
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/source/API-Reference.rst
+++ b/docs/source/API-Reference.rst
@@ -1058,6 +1058,7 @@ CircularPort()
       flange_thickness=10,
       wall_thickness=2,
       distance = 50,
+      flange_gap=1,
    )
 
    cadquery_object = my_component.solid

--- a/docs/source/API-Reference.rst
+++ b/docs/source/API-Reference.rst
@@ -1051,7 +1051,7 @@ CircularPort()
    :select: cadquery_object
    :gridsize: 0
 
-   component = paramak.CircularPort(
+   my_component = paramak.CircularPort(
       color = (0,1,0),
       rotation_angle=45,
       blank_flange_thickness=4,
@@ -1067,7 +1067,7 @@ CircularPort()
    :select: cadquery_object
    :gridsize: 0
 
-   component = paramak.CircularPort(
+   my_component = paramak.CircularPort(
       inner_radius = 20,
       azimuth_placement_angle= [0.,  30.,  60.,  90., 120., 150., 180., 210., 240., 270., 300., 330.],
          color = (0,1,0),
@@ -1081,9 +1081,8 @@ CircularPort()
 
    cadquery_object = my_component.solid
 
-|CircularPortRotatedsvg|
 
-.. |CircularPortRotatedsvg| image:: https://user-images.githubusercontent.com/8583900/159140637-ee6c72f8-1094-4261-90a2-b137b2777c92.png
+.. image:: https://user-images.githubusercontent.com/8583900/159140637-ee6c72f8-1094-4261-90a2-b137b2777c92.png
     :width: 380px
 
 .. automodule:: paramak.parametric_components.circular_port

--- a/examples/example_parametric_components/make_components_other.ipynb
+++ b/examples/example_parametric_components/make_components_other.ipynb
@@ -68,6 +68,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "component = paramak.CircularPort(\n",
+    "    color = (0,1,0),\n",
+    "    rotation_angle=45,\n",
+    "    blank_flange_thickness=4,\n",
+    "    flange_thickness=10,\n",
+    "    wall_thickness=2,\n",
+    "    distance = 50,\n",
+    ")\n",
+    "component.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "component = paramak.PortCutterRotated(\n",
     "    center_point=(450, 0),\n",
     "    polar_coverage_angle=20,\n",
@@ -276,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -31,6 +31,7 @@ from .parametric_shapes.sweep_spline_shape import SweepSplineShape
 from .parametric_shapes.sweep_straight_shape import SweepStraightShape
 from .parametric_shapes.sweep_circle_shape import SweepCircleShape
 
+from .parametric_components.circular_port import CircularPort
 from .parametric_components.hexagon_pin import HexagonPin
 
 from .parametric_components.tokamak_plasma import Plasma

--- a/paramak/parametric_components/circular_port.py
+++ b/paramak/parametric_components/circular_port.py
@@ -1,0 +1,146 @@
+from typing import Optional, Tuple
+from paramak import Shape
+from cadquery import Workplane
+from paramak.utils import calculate_wedge_cut
+
+
+class CircularPort(Shape):
+    """Creates an extruded pipe with a flange end and optional.
+
+    Args:
+        inner_radius: inner_radius (cm) of tubular section.
+        distance: extruded distance (cm) of the tubular section.
+        wall_thickness: the radial thickness of the  tubular section wall.
+        flange_overhang: the distance of the flange overhang or lip.
+        flange_thickness: the thickness of the flange, should be a positive
+            number. Set to None if no blank flange is required.
+        blank_flange_thickness: the thickness of the blank flange
+        center_point: center point of the port cutter. Defaults to (0, 0).
+        workplane: workplane in which the port cutters are created. Defaults
+            to "ZY".
+        rotation_axis: axis around which the port cutters are rotated and
+            placed. Defaults to "Z".
+        extrusion_start_offset: the distance between 0 and the start of the
+            extrusion. Defaults to 1..
+        name: defaults to "circular_port_cutter".
+    """
+
+    def __init__(
+        self,
+        inner_radius: float = 30,
+        distance: float = 20,
+        wall_thickness: float = 2,
+        flange_overhang: float = 10,
+        flange_thickness: float = 5,
+        flange_gap: float = 0,
+        blank_flange_thickness: Optional[float] = 5,
+        workplane: Optional[str] = "ZY",
+        rotation_axis: Optional[str] = "Z",
+        extrusion_start_offset: Optional[float] = 100,
+        center_point: Optional[tuple] = (0, 0),
+        name: Optional[str] = "circular_port_cutter",
+        color: Tuple[float, float, float, Optional[float]] = (
+            0.984,
+            0.603,
+            0.6,
+        ),
+        rotation_angle: float = 360,
+        **kwargs,
+    ):
+        super().__init__(color=color, name=name, **kwargs)
+
+        self.inner_radius = inner_radius
+        self.distance = distance
+        self.wall_thickness = wall_thickness
+        self.flange_overhang = flange_overhang
+        self.flange_thickness = flange_thickness
+        self.flange_gap = flange_gap
+        self.blank_flange_thickness = blank_flange_thickness
+        self.workplane = workplane
+        self.rotation_axis = rotation_axis
+        self.extrusion_start_offset = extrusion_start_offset
+        self.center_point = center_point
+        self.rotation_angle = rotation_angle
+
+    def find_points(self):
+        self.points = [self.center_point]
+
+    def create_solid(self):
+        """Creates a extruded 3d solid using points with circular edges.
+
+        Returns:
+           A CadQuery solid: A 3D solid volume
+        """
+
+        # so a positive offset moves extrusion further from axis of azimuthal
+        # placement rotation
+        if self.extrusion_start_offset is None:
+            extrusion_offset = 0.
+        else:
+            extrusion_offset = -self.extrusion_start_offset
+        flange_gap = -self.flange_gap
+        extrusion_distance = -self.distance
+        flange_thickness = self.flange_thickness
+
+        inner_wire = (
+            Workplane(self.workplane)
+            .workplane(offset=extrusion_offset)
+            .moveTo(self.points[0][0], self.points[0][1])
+            .circle(self.inner_radius)
+        )
+        inner_solid = inner_wire.extrude(until=extrusion_distance - flange_thickness, both=False)
+
+        outer_wire = (
+            Workplane(self.workplane)
+            .workplane(offset=extrusion_offset)
+            .moveTo(self.points[0][0], self.points[0][1])
+            .circle(self.inner_radius + self.wall_thickness)
+        )
+        outer_solid = outer_wire.extrude(until=extrusion_distance, both=False)
+
+        flange_wire = (
+            Workplane(self.workplane)
+            .workplane(offset=extrusion_offset + extrusion_distance)
+            .moveTo(self.points[0][0], self.points[0][1])
+            .circle(self.inner_radius + self.wall_thickness + self.flange_overhang)
+        )
+        flange_solid = flange_wire.extrude(until=flange_thickness, both=False)
+
+        solid = outer_solid.cut(inner_solid)
+        flange_solid = flange_solid.cut(inner_solid)
+        solid = solid.union(flange_solid)
+
+        # changing value internally so that 0 can be used in additions
+        if self.blank_flange_thickness is None:
+            blank_flange_thickness = 0
+        else:
+            blank_flange_thickness = self.blank_flange_thickness
+
+        if blank_flange_thickness > 0:
+            blank_flange_wire = (
+                Workplane(self.workplane)
+                .workplane(offset=extrusion_offset + extrusion_distance + flange_gap - self.blank_flange_thickness)
+                .moveTo(self.points[0][0], self.points[0][1])
+                .circle(self.inner_radius + self.wall_thickness + self.flange_overhang)
+            )
+            blank_flange_solid = blank_flange_wire.extrude(until=blank_flange_thickness, both=False)
+            solid = solid.union(blank_flange_solid)
+        elif blank_flange_thickness < 0:
+            msg = f"blank_flange_thickness should be larger than 0 or None. Not {blank_flange_thickness}"
+            raise ValueError(msg)
+
+        # TODO combine all wires into one
+        # self.wire = solid.Wires()
+
+        solid = self.rotate_solid(solid)
+
+        # calculates the size of the component as these attributes are used
+        # when making the cutting wedge
+        self.radius = self.extrusion_start_offset + self.distance + self.flange_thickness + blank_flange_thickness
+        self.height = self.center_point[0] + self.inner_radius + self.wall_thickness
+
+        cutting_wedge = calculate_wedge_cut(self)
+        solid = self.perform_boolean_operations(solid, wedge_cut=cutting_wedge)
+        self.solid = solid
+
+        return solid

--- a/tests/test_parametric_components/test_circular_port.py
+++ b/tests/test_parametric_components/test_circular_port.py
@@ -1,0 +1,60 @@
+
+import unittest
+
+import paramak
+
+
+class TestCircularPort(unittest.TestCase):
+    def setUp(self):
+        
+        self.test_shape = paramak.CircularPort(
+            inner_radius = 20,
+            azimuth_placement_angle=[0.,  30.,  60.,  90., 120., 150., 180., 210., 240., 270., 300., 330.],
+            color = (0,1,0),
+            rotation_angle=180,
+            blank_flange_thickness=4,
+            flange_thickness=10,
+            wall_thickness=2,
+            distance = 50,
+            flange_gap=0
+        )
+
+    def test_default_parameters(self):
+        """Checks that the default parameters of a CircularPort are correct."""
+
+        assert self.test_shape.inner_radius == 20
+        assert self.test_shape.rotation_angle == 180
+        assert self.test_shape.blank_flange_thickness == 4
+        assert self.test_shape.flange_thickness == 10
+        assert self.test_shape.wall_thickness == 2
+        assert self.test_shape.distance == 50
+        assert self.test_shape.flange_gap == 0
+        
+    def test_creation(self):
+        """Creates a circular port cutter using the CircularPort parametric
+        component and checks that a cadquery solid is created."""
+
+        assert self.test_shape.solid is not None
+        assert self.test_shape.volume() > 1000
+
+    def test_gap_makes_extra_surfaces(self):
+        """Creates a circular port cutter using the CircularPort parametric
+        component and checks that a cadquery solid with the right number of
+        surfaces is created."""
+
+        self.test_shape.azimuth_placement_angle = [0]
+        self.test_shape.rotation_angle = 360
+        assert len(self.test_shape.solid.val().Faces()) == 7
+        self.test_shape.flange_gap = 1
+        assert len(self.test_shape.solid.val().Faces()) == 9
+
+    def test_gap_and_cut_makes_extra_surfaces(self):
+        """Creates a circular port cutter using the CircularPort parametric
+        component and checks that a cadquery solid with the right number of
+        surfaces is created."""
+
+        self.test_shape.azimuth_placement_angle = [0]
+        self.test_shape.rotation_angle = 180  # this cuts the shape in half
+        assert len(self.test_shape.solid.val().Faces()) == 8
+        self.test_shape.flange_gap = 1
+        assert len(self.test_shape.solid.val().Faces()) == 12


### PR DESCRIPTION
## Proposed changes

Adds a circular port parametric component that is a pipe with a flange. An svg image was made with and can be uploaded to the docs later

```
component.export_svg('/home/jshimwell/paramak/port.svg', projectionDir=(-0.1, -0.45, 1))
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
