### PR TITLE
added example non breaking change

### DIFF
--- a/docs/source/API-Reference.rst
+++ b/docs/source/API-Reference.rst
@@ -1,8 +1,8 @@
 API-Reference
 *************
 
-Parametric Shapes
-=================
+Parametric Shapes non breaking change to docs
+=============================================
 
 
 Rotated Shapes


### PR DESCRIPTION
## Proposed changes

Here is an example of a PR that breaks the docs.
This should:
   not run any of the normal CI due to the use of paths in the yml files
   still run the readthedocs build
