### PR TITLE
Adding tests for dagmc export to other codes

### DIFF
--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -265,7 +265,7 @@ class Reactor:
                     "When specifying tags then there must be one tag for "
                     "every shape in the reactor. Currently there are "
                     f"{len(tags)} tags provided and "
-                    f"{len(shapes_and_components)} shapes in the reactor"
+                    f"{len(self.shapes_and_components)} shapes in the reactor"
                 )
                 raise ValueError(msg)
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -218,10 +218,11 @@ class Reactor:
         min_mesh_size: float = 5,
         max_mesh_size: float = 20,
         exclude: List[str] = None,
-        verbose=False,
-        volume_atol=0.000001,
-        center_atol=0.000001,
-        bounding_box_atol=0.000001,
+        verbose: bool=False,
+        volume_atol: float=0.000001,
+        center_atol: float=0.000001,
+        bounding_box_atol: float=0.000001,
+        tags: Optional[List[str]] = None
     ) -> str:
         """Export a DAGMC compatible h5m file for use in neutronics simulations.
         This method makes use of Gmsh to create a surface mesh of the geometry.
@@ -248,11 +249,25 @@ class Reactor:
             bounding_box_atol: the absolute volume tolerance to allow when
                 matching parts in the intermediate brep file with the cadquery
                 parts
+            tags: the dagmc tag to use in when naming the shape in the h5m file.
+                If left as None then the Shape.name will be used. This allows
+                the DAGMC geometry created to be compatible with a wider range
+                of neutronics codes that have specific DAGMC tag requirements.
         """
 
         # a local import is used here as these packages need CQ master to work
         from brep_to_h5m import brep_to_h5m
         import brep_part_finder as bpf
+        
+        if tags:
+            if len(tags) != len(self.shapes_and_components):
+                msg = (
+                    'When specifying tags then there must be one tag for '
+                    'every shape in the reactor. Currently there are '
+                    f'{len(tags)} tags provided and '
+                    f'{len(shapes_and_components)} shapes in the reactor'
+                )
+                raise ValueError(msg)
 
         tmp_brep_filename = tempfile.mkstemp(suffix=".brep", prefix="paramak_")[1]
 
@@ -266,7 +281,7 @@ class Reactor:
             print("brep_file_part_properties", brep_file_part_properties)
 
         shape_properties = {}
-        for shape_or_compound in self.shapes_and_components:
+        for counter, shape_or_compound in enumerate(self.shapes_and_components):
             sub_solid_descriptions = []
 
             # checks if the solid is a cq.Compound or not
@@ -287,8 +302,11 @@ class Reactor:
                     ),
                 }
                 sub_solid_descriptions.append(sub_solid_description)
-            shape_properties[shape_or_compound.name] = sub_solid_descriptions
-
+            if tags:
+                shape_properties[tags[counter]] = sub_solid_descriptions
+            else:
+                shape_properties[shape_or_compound.name] = sub_solid_descriptions
+            
         if verbose:
             print("shape_properties", shape_properties)
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -806,6 +806,7 @@ class Shape:
         filename: str = "dagmc.h5m",
         min_mesh_size: float = 10,
         max_mesh_size: float = 20,
+        tag: Optional[str] = None
     ) -> str:
         """Export a DAGMC compatible h5m file for use in neutronics simulations.
         This method makes use of Gmsh to create a surface mesh of the geometry.
@@ -819,6 +820,10 @@ class Shape:
                 into gmsh.option.setNumber("Mesh.MeshSizeMin", min_mesh_size)
             max_mesh_size: the maximum mesh element size to use in Gmsh. Passed
                 into gmsh.option.setNumber("Mesh.MeshSizeMax", max_mesh_size)
+            tag: the dagmc tag to use in when naming the shape in the h5m file.
+                If left as None then the Shape.name will be used. This allows
+                the DAGMC geometry created to be compatible with a wider range
+                of neutronics codes that have specific DAGMC tag requirements.
         """
 
         from brep_to_h5m import brep_to_h5m
@@ -830,7 +835,10 @@ class Shape:
 
         volumes_with_tags = {}
         for counter, _ in enumerate(self.solid.val().Solids(), 1):
-            volumes_with_tags[counter] = f"mat_{self.name}"
+            if tag:
+                volumes_with_tags[counter] = f"{tag}"
+            else:
+                volumes_with_tags[counter] = f"{self.name}"
 
         brep_to_h5m(
             brep_filename=tmp_brep_filename,

--- a/tests_h5m/test_reactor_export_h5m.py
+++ b/tests_h5m/test_reactor_export_h5m.py
@@ -77,6 +77,20 @@ class TestReactor(unittest.TestCase):
 
         assert Path("dagmc_bigger.h5m").stat().st_size > Path("dagmc_default.h5m").stat().st_size
 
+    def test_dagmc_h5m_export_error_handling(self):
+        """Exports a shape with the wrong amount of tags"""
+
+        def too_few_tags():
+            self.test_reactor_3.rotation_angle = 180
+            self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", tags=["1"])          
+        
+        self.assertRaises(ValueError, too_few_tags)
+        
+        def too_many_tags():
+            self.test_reactor_3.rotation_angle = 180
+            self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", tags=["1", "2", "3"])          
+
+        self.assertRaises(ValueError, too_many_tags)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests_h5m/test_reactor_export_h5m.py
+++ b/tests_h5m/test_reactor_export_h5m.py
@@ -26,9 +26,30 @@ class TestReactor(unittest.TestCase):
         # this reactor has a compound shape in the geometry
         self.test_reactor_3 = paramak.Reactor([self.test_shape, test_shape_3])
 
+    def test_dagmc_h5m_custom_tags_export(self):
+        """Exports a reactor with two shapes checks that the tags are correctly
+        named in the resulting h5m file"""
+
+        self.test_reactor_3.rotation_angle = 180
+        self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", tags=['1','2'])
+
+        vols = di.get_volumes_from_h5m("dagmc_reactor.h5m")
+        assert vols == [1, 2, 3]  # there are three volumes in test_reactor_3
+
+        mats = di.get_materials_from_h5m("dagmc_reactor.h5m")
+        print(mats)
+        assert mats == ["1", "2"]
+
+        vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_reactor.h5m")
+        assert vols_and_mats == {
+            1: "1",
+            2: "2",
+            3: "2",
+        }
+
     def test_dagmc_h5m_export(self):
-        """Exports a shape with a single volume and checks that it
-        exist (volume id and material tag) in the resulting h5m file"""
+        """Exports a reactor with two shapes checks that the tags are correctly
+        named in the resulting h5m file"""
 
         self.test_reactor_3.rotation_angle = 180
         self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m")

--- a/tests_h5m/test_rotate_straight_shape_export_h5m.py
+++ b/tests_h5m/test_rotate_straight_shape_export_h5m.py
@@ -24,14 +24,14 @@ class TestRotateStraightShape(unittest.TestCase):
         assert vols == [1, 2, 3, 4]
 
         mats = di.get_materials_from_h5m("dagmc_multi_volume.h5m")
-        assert mats == ["mat_my_material_name"]
+        assert mats == ["my_material_name"]
 
         vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_multi_volume.h5m")
         assert vols_and_mats == {
-            1: "mat_my_material_name",
-            2: "mat_my_material_name",
-            3: "mat_my_material_name",
-            4: "mat_my_material_name",
+            1: "my_material_name",
+            2: "my_material_name",
+            3: "my_material_name",
+            4: "my_material_name",
         }
 
     def test_dagmc_h5m_export_custom_tag_multi_volume(self):
@@ -47,7 +47,7 @@ class TestRotateStraightShape(unittest.TestCase):
         assert vols == [1, 2, 3, 4]
 
         mats = di.get_materials_from_h5m("dagmc_multi_volume.h5m")
-        assert mats == ["mat_my_material_name"]
+        assert mats == ["my_material_name"]
 
         vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_multi_volume.h5m")
         assert vols_and_mats == {
@@ -69,10 +69,10 @@ class TestRotateStraightShape(unittest.TestCase):
         assert vols == [1]
 
         mats = di.get_materials_from_h5m("dagmc_single_volume.h5m")
-        assert mats == ["mat_my_material_name_single"]
+        assert mats == ["my_material_name_single"]
 
         vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_single_volume.h5m")
-        assert vols_and_mats == {1: "mat_my_material_name_single"}
+        assert vols_and_mats == {1: "my_material_name_single"}
 
     def test_dagmc_h5m_export_single_volume_custom_tags(self):
         """Exports a shape with a single volume and checks that it
@@ -88,7 +88,7 @@ class TestRotateStraightShape(unittest.TestCase):
         assert mats == ["1"]
 
         vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_single_volume.h5m")
-        assert vols_and_mats == {1: "mat_my_material_name_single"}
+        assert vols_and_mats == {1: "my_material_name_single"}
 
     def test_dagmc_h5m_export_mesh_size(self):
         """Exports h5m file with higher resolution mesh and checks that the

--- a/tests_h5m/test_rotate_straight_shape_export_h5m.py
+++ b/tests_h5m/test_rotate_straight_shape_export_h5m.py
@@ -99,6 +99,6 @@ class TestRotateStraightShape(unittest.TestCase):
 
         assert Path("dagmc_bigger.h5m").stat().st_size > Path("dagmc_default.h5m").stat().st_size
 
-
+        
 if __name__ == "__main__":
     unittest.main()

--- a/tests_h5m/test_rotate_straight_shape_export_h5m.py
+++ b/tests_h5m/test_rotate_straight_shape_export_h5m.py
@@ -41,7 +41,7 @@ class TestRotateStraightShape(unittest.TestCase):
         self.test_shape.rotation_angle = 10
         self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
         self.test_shape.name = "my_material_name"
-        self.test_shape.export_dagmc_h5m("dagmc_multi_volume.h5m", tags=['1'])
+        self.test_shape.export_dagmc_h5m("dagmc_multi_volume.h5m", tag='1')
 
         vols = di.get_volumes_from_h5m("dagmc_multi_volume.h5m")
         assert vols == [1, 2, 3, 4]
@@ -79,7 +79,7 @@ class TestRotateStraightShape(unittest.TestCase):
         exist (volume id and custom material tag) in the resulting h5m file"""
 
         self.test_shape.rotation_angle = 180
-        self.test_shape.export_dagmc_h5m("dagmc_custom_tag_single_volume.h5m", tags=['1'])
+        self.test_shape.export_dagmc_h5m("dagmc_custom_tag_single_volume.h5m", tag='1')
 
         vols = di.get_volumes_from_h5m("dagmc_custom_tag_single_volume.h5m")
         assert vols == [1]

--- a/tests_h5m/test_rotate_straight_shape_export_h5m.py
+++ b/tests_h5m/test_rotate_straight_shape_export_h5m.py
@@ -34,6 +34,29 @@ class TestRotateStraightShape(unittest.TestCase):
             4: "mat_my_material_name",
         }
 
+    def test_dagmc_h5m_export_custom_tag_multi_volume(self):
+        """Exports a shape with multiple volumes and checks that they all
+        exist (volume ids and material tags) in the resulting h5m file"""
+
+        self.test_shape.rotation_angle = 10
+        self.test_shape.azimuth_placement_angle = [0, 90, 180, 270]
+        self.test_shape.name = "my_material_name"
+        self.test_shape.export_dagmc_h5m("dagmc_multi_volume.h5m", tags=['1'])
+
+        vols = di.get_volumes_from_h5m("dagmc_multi_volume.h5m")
+        assert vols == [1, 2, 3, 4]
+
+        mats = di.get_materials_from_h5m("dagmc_multi_volume.h5m")
+        assert mats == ["mat_my_material_name"]
+
+        vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_multi_volume.h5m")
+        assert vols_and_mats == {
+            1: "1",
+            2: "1",
+            3: "1",
+            4: "1",
+        }
+
     def test_dagmc_h5m_export_single_volume(self):
         """Exports a shape with a single volume and checks that it
         exist (volume id and material tag) in the resulting h5m file"""
@@ -47,6 +70,22 @@ class TestRotateStraightShape(unittest.TestCase):
 
         mats = di.get_materials_from_h5m("dagmc_single_volume.h5m")
         assert mats == ["mat_my_material_name_single"]
+
+        vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_single_volume.h5m")
+        assert vols_and_mats == {1: "mat_my_material_name_single"}
+
+    def test_dagmc_h5m_export_single_volume_custom_tags(self):
+        """Exports a shape with a single volume and checks that it
+        exist (volume id and custom material tag) in the resulting h5m file"""
+
+        self.test_shape.rotation_angle = 180
+        self.test_shape.export_dagmc_h5m("dagmc_custom_tag_single_volume.h5m", tags=['1'])
+
+        vols = di.get_volumes_from_h5m("dagmc_custom_tag_single_volume.h5m")
+        assert vols == [1]
+
+        mats = di.get_materials_from_h5m("dagmc_custom_tag_single_volume.h5m")
+        assert mats == ["1"]
 
         vols_and_mats = di.get_volumes_and_materials_from_h5m("dagmc_single_volume.h5m")
         assert vols_and_mats == {1: "mat_my_material_name_single"}


### PR DESCRIPTION
## Proposed changes

As discussed in issue #233 this PR adds support for custom tags to be exported to dagmc h5m files.

TODO
add option to include the graveyard when exporting to dagmc geometry. I might need to rework the graveyard feature a bit before adding this

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
