### PR TITLE
Centering graveyard when using offset

### DIFF
--- a/paramak/__init__.py
+++ b/paramak/__init__.py
@@ -23,6 +23,7 @@ from .utils import (
     find_radius_of_circle,
     export_solids_to_brep,
     export_solids_to_dagmc_h5m,
+    get_center_of_bounding_box,
 )
 from .utils import EdgeLengthSelector, FaceAreaSelector
 

--- a/paramak/parametric_components/extrude_hollow_rectangle.py
+++ b/paramak/parametric_components/extrude_hollow_rectangle.py
@@ -8,9 +8,10 @@ class ExtrudeHollowRectangle(ExtrudeStraightShape):
     """Creates a rectangular with a hollow section extrusion.
 
     Args:
-        height: the vertical (z axis) height of the rectangle (cm).
-        width: the horizontal (x axis) width of the rectangle (cm).
-        casing_thickness: the thickness of the casing (cm).
+        height: the height of the internal hollow section.
+        width: the width of the internal hollow section.
+        distance: the depth of the internal hollow section.
+        casing_thickness: the thickness of the casing around the hollow section.
         center_point: the center of the rectangle (x,z) values (cm).
         name: defaults to "extrude_rectangle".
     """
@@ -82,7 +83,7 @@ class ExtrudeHollowRectangle(ExtrudeStraightShape):
         #   9-------------6
         #   | 4 -------5,1|
         #   | |         | |
-        #   | |  (0,0)  | |
+        #   | |   cp    | |
         #   | |         | |
         #   | 3 ------- 2 |
         #   8-------------7

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -1,5 +1,5 @@
 import cadquery as cq
-
+from typing import Tuple
 from paramak import Shape
 
 
@@ -8,14 +8,22 @@ class HollowCube(Shape):
     Graveyard.
 
     Arguments:
-        length (float): The length to use for the height, width, depth of the
+        length: The length to use for the height, width, depth of the
             inner dimensions of the cube.
-        thickness (float, optional): thickness of the vessel. Defaults to 10.0.
+        thickness: thickness of the vessel.
+        center_coordinate: the location the center of the cube.
     """
 
-    def __init__(self, length, thickness=10.0, **kwargs):
+    def __init__(
+        self,
+        length: float,
+        thickness: float = 10.0,
+        center_coordinate: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        **kwargs
+    ):
         self.length = length
         self.thickness = thickness
+        self.center_coordinate = center_coordinate
         super().__init__(**kwargs)
 
     @property
@@ -37,13 +45,17 @@ class HollowCube(Shape):
     def create_solid(self):
 
         # creates a small box that surrounds the geometry
-        inner_box = cq.Workplane("front").box(self.length, self.length, self.length)
+        inner_box = cq.Workplane("front").box(self.length, self.length, self.length).translate(self.center_coordinate)
 
         # creates a large box that surrounds the smaller box
-        outer_box = cq.Workplane("front").box(
-            self.length + self.thickness,
-            self.length + self.thickness,
-            self.length + self.thickness,
+        outer_box = (
+            cq.Workplane("front")
+            .box(
+                self.length + self.thickness,
+                self.length + self.thickness,
+                self.length + self.thickness,
+            )
+            .translate(self.center_coordinate)
         )
 
         # subtracts the two boxes to leave a hollow box

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -19,12 +19,13 @@ class HollowCube(Shape):
         length: float,
         thickness: float = 10.0,
         center_coordinate: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        name="hollow_cube",
         **kwargs
     ):
+        super().__init__(name=name, **kwargs)
         self.length = length
         self.thickness = thickness
         self.center_coordinate = center_coordinate
-        super().__init__(**kwargs)
 
     @property
     def thickness(self):

--- a/paramak/parametric_components/hollow_cube.py
+++ b/paramak/parametric_components/hollow_cube.py
@@ -1,5 +1,6 @@
-import cadquery as cq
 from typing import Tuple
+
+import cadquery as cq
 from paramak import Shape
 
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -35,7 +35,7 @@ class Reactor:
     def __init__(
         self,
         shapes_and_components: List[paramak.Shape] = [],
-        graveyard_size: float = 20_000.0,
+        graveyard_size: Optional[float] = None,
         graveyard_offset: Optional[float] = None,
     ):
 
@@ -690,10 +690,15 @@ class Reactor:
                 Please specify at least one of these attributes or arguments"
             )
 
-        graveyard_shape = paramak.HollowCube(
-            length=graveyard_size_to_use,
-            name="graveyard",
+        # makes the graveyard around the center of the geometry
+        bb = self.bounding_box
+        center = (
+            (bb[0][0] + bb[1][0]) / 2,
+            (bb[0][1] + bb[1][1]) / 2,
+            (bb[0][2] + bb[1][2]) / 2,
         )
+
+        graveyard_shape = paramak.HollowCube(length=graveyard_size_to_use, name="graveyard", center_coordinate=center)
 
         self.graveyard = graveyard_shape
 

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -616,44 +616,6 @@ class Reactor:
 
         return str(path_filename)
 
-    # def export_stp_graveyard(
-    #     self,
-    #     filename: Optional[str] = "graveyard.stp",
-    #     graveyard_size: Optional[float] = None,
-    #     graveyard_offset: Optional[float] = None,
-    # ) -> str:
-    #     """Writes a stp file (CAD geometry) for the reactor graveyard. This
-    #     is needed for DAGMC simulations. This method also calls
-    #     Reactor.make_graveyard() with the graveyard_size and graveyard_size
-    #     values.
-
-    #     Args:
-    #         filename (str): the filename for saving the stp file. Appends
-    #             .stp to the filename if it is missing.
-    #         graveyard_size: directly sets the size of the graveyard. Defaults
-    #             to None which then uses the Reactor.graveyard_size attribute.
-    #         graveyard_offset: the offset between the largest edge of the
-    #             geometry and inner bounding shell created. Defaults to None
-    #             which then uses Reactor.graveyard_offset attribute.
-
-    #     Returns:
-    #         str: the stp filename created
-    #     """
-
-    #     graveyard = self.make_graveyard(
-    #         offset=graveyard_offset,
-    #         size=graveyard_size,
-    #     )
-
-    #     path_filename = Path(filename)
-
-    #     if path_filename.suffix != ".stp":
-    #         path_filename = path_filename.with_suffix(".stp")
-
-    #     graveyard.export_stp(filename=str(path_filename))
-
-    #     return str(path_filename)
-
     def make_graveyard(
         self,
         size: Optional[float] = None,

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -216,8 +216,8 @@ class Shape:
 
     @property
     def largest_dimension(self) -> float:
-        """Calculates the distance from (0, 0, 0) to the furthest part of
-        the geometry. This distance is returned as an positive value."""
+        """Calculates a bounding box for the Reactor and returns the largest
+        absolute value of the largest dimension of the bounding box"""
 
         return get_largest_dimension(self.solid)
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -59,7 +59,7 @@ def export_solids_to_brep(
         if isinstance(solid, cq.occ_impl.shapes.Compound):
             bldr.AddArgument(solid.wrapped)
         else:
-            bldr.AddArgument(solid.wrapped)
+            bldr.AddArgument(solid.val().wrapped)
 
     bldr.SetNonDestructive(True)
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -135,13 +135,7 @@ def export_solids_to_dagmc_h5m(
     # request to find part ids that are mixed up in the Brep file
     # using the volume, center, bounding box that we know about when creating the
     # CAD geometry in the first place
-    print()
-    print()
-    print()
-    print(brep_file_part_properties)
-    print()
-    print()
-    print()
+
     key_and_part_id = bpf.get_dict_of_part_ids(
         brep_part_properties=brep_file_part_properties,
         shape_properties=shape_properties,

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -18,18 +18,14 @@ import OCP
 
 
 def export_solids_to_brep(
-    solids,
+    solids: Iterable,
     filename: str = "reactor.brep",
 ):
     """Exports a brep file for the Reactor.solid.
 
     Args:
+        solids: a list of cadquery solids
         filename: the filename of exported the brep file.
-        merge: if the surfaces should be merged (True) or not (False).
-        include_graveyard: specify if the graveyard will be included or
-            not. If True the the Reactor.make_graveyard will be called
-            using Reactor.graveyard_size and Reactor.graveyard_offset
-            attribute values.
 
     Returns:
         filename of the brep created
@@ -194,7 +190,36 @@ def get_bounding_box(solid) -> Tuple[Tuple[float, float, float], Tuple[float, fl
     return (lower_left, upper_right)
 
 
+def get_center_of_bounding_box(solid):
+    """Calculates the geometric center of the solids bounding box"""
+
+    bounding_box = get_bounding_box(solid)
+
+    center = (
+        (bounding_box[0][0] + bounding_box[1][0]) / 2,
+        (bounding_box[0][1] + bounding_box[1][1]) / 2,
+        (bounding_box[0][2] + bounding_box[1][2]) / 2,
+    )
+
+    return center
+
+
 def get_largest_dimension(solid):
+    """Calculates the extent of the geometry in the x,y and z axis and returns
+    the largest of the three."""
+
+    bounding_box = get_bounding_box(solid)
+
+    largest_dimension = max(
+        abs(bounding_box[0][0] - bounding_box[0][1]),
+        abs(bounding_box[0][2] - bounding_box[1][0]),
+        abs(bounding_box[1][1] - bounding_box[1][2]),
+    )
+
+    return largest_dimension
+
+
+def get_largest_distance_from_origin(solid):
     """Calculates the distance from (0, 0, 0) to the furthest part of
     the geometry. This distance is returned as an positive value."""
 

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -59,7 +59,7 @@ def export_solids_to_brep(
         if isinstance(solid, cq.occ_impl.shapes.Compound):
             bldr.AddArgument(solid.wrapped)
         else:
-            bldr.AddArgument(solid.val().wrapped)
+            bldr.AddArgument(solid.wrapped)
 
     bldr.SetNonDestructive(True)
 
@@ -139,6 +139,13 @@ def export_solids_to_dagmc_h5m(
     # request to find part ids that are mixed up in the Brep file
     # using the volume, center, bounding box that we know about when creating the
     # CAD geometry in the first place
+    print()
+    print()
+    print()
+    print(brep_file_part_properties)
+    print()
+    print()
+    print()
     key_and_part_id = bpf.get_dict_of_part_ids(
         brep_part_properties=brep_file_part_properties,
         shape_properties=shape_properties,

--- a/tests/test_parametric_components/test_extrude_hollow_cube.py
+++ b/tests/test_parametric_components/test_extrude_hollow_cube.py
@@ -5,19 +5,19 @@ import pytest
 import paramak
 
 
-class TestExtrudeHollowRectangle(unittest.TestCase):
+class TestHollowCube(unittest.TestCase):
     def setUp(self):
-        self.test_shape = paramak.ExtrudeHollowRectangle(height=10, width=15, casing_thickness=1, distance=2)
+        self.test_shape = paramak.HollowCube(height=10, width=15, casing_thickness=1, distance=2)
 
     def test_default_parameters(self):
-        """Checks that the default parameters of a ExtrudeHollowRectangle are
+        """Checks that the default parameters of a HollowCube are
         correct."""
 
         assert self.test_shape.center_point == (0, 0)
 
     def test_processed_points_calculation(self):
         """Checks that the processed_points used to construct the
-        ExtrudeHollowRectangle are calculated correctly from the parameters given."""
+        HollowCube are calculated correctly from the parameters given."""
 
         assert self.test_shape.processed_points == [
             (7.5, 5.0, "straight"),
@@ -34,7 +34,7 @@ class TestExtrudeHollowRectangle(unittest.TestCase):
         ]
 
     def test_points_calculation(self):
-        """Checks that the points used to construct the ExtrudeHollowRectangle are
+        """Checks that the points used to construct the HollowCube are
         calculated correctly from the parameters given."""
 
         assert self.test_shape.points == [
@@ -51,20 +51,20 @@ class TestExtrudeHollowRectangle(unittest.TestCase):
         ]
 
     def test_creation(self):
-        """Creates a rectangular extrusion using the ExtrudeHollowRectangle
+        """Creates a rectangular extrusion using the HollowCube
         parametric component and checks that a cadquery solid is created."""
 
         assert self.test_shape.solid is not None
         assert self.test_shape.volume() > 100
 
     def test_absolute_volume(self):
-        """Creates a rectangular extrusion using the ExtrudeHollowRectangle
+        """Creates a rectangular extrusion using the HollowCube
         parametric component and checks that the volume is correct"""
 
         assert self.test_shape.volume() == pytest.approx((17 * 12 * 2) - (15 * 10 * 2))
 
     def test_absolute_areas(self):
-        """Creates a rectangular extrusion using the ExtrudeHollowRectangle
+        """Creates a rectangular extrusion using the HollowCube
         parametric component and checks that the areas are correct"""
 
         assert len(self.test_shape.areas) == 10

--- a/tests/test_parametric_components/test_extrude_hollow_cube.py
+++ b/tests/test_parametric_components/test_extrude_hollow_cube.py
@@ -5,6 +5,7 @@ import paramak
 
 class TestHollowCube(unittest.TestCase):
     """tests the hoolw cube shape that is used as a graveyard"""
+
     def setUp(self):
         self.test_shape = paramak.HollowCube(length=10, thickness=2)
 

--- a/tests/test_parametric_components/test_extrude_hollow_cube.py
+++ b/tests/test_parametric_components/test_extrude_hollow_cube.py
@@ -1,11 +1,10 @@
 import unittest
 
-import pytest
-
 import paramak
 
 
 class TestHollowCube(unittest.TestCase):
+    """tests the hoolw cube shape that is used as a graveyard"""
     def setUp(self):
         self.test_shape = paramak.HollowCube(length=10, thickness=2)
 

--- a/tests/test_parametric_components/test_extrude_hollow_cube.py
+++ b/tests/test_parametric_components/test_extrude_hollow_cube.py
@@ -7,79 +7,30 @@ import paramak
 
 class TestHollowCube(unittest.TestCase):
     def setUp(self):
-        self.test_shape = paramak.HollowCube(height=10, width=15, casing_thickness=1, distance=2)
+        self.test_shape = paramak.HollowCube(length=10, thickness=2)
 
     def test_default_parameters(self):
         """Checks that the default parameters of a HollowCube are
         correct."""
 
-        assert self.test_shape.center_point == (0, 0)
-
-    def test_processed_points_calculation(self):
-        """Checks that the processed_points used to construct the
-        HollowCube are calculated correctly from the parameters given."""
-
-        assert self.test_shape.processed_points == [
-            (7.5, 5.0, "straight"),
-            (7.5, -5.0, "straight"),
-            (-7.5, -5.0, "straight"),
-            (-7.5, 5.0, "straight"),
-            (7.5, 5.0, "straight"),
-            (8.5, 6.0, "straight"),
-            (8.5, -6.0, "straight"),
-            (-8.5, -6.0, "straight"),
-            (-8.5, 6.0, "straight"),
-            (8.5, 6.0, "straight"),
-            (7.5, 5.0, "straight"),
-        ]
-
-    def test_points_calculation(self):
-        """Checks that the points used to construct the HollowCube are
-        calculated correctly from the parameters given."""
-
-        assert self.test_shape.points == [
-            (7.5, 5.0),
-            (7.5, -5.0),
-            (-7.5, -5.0),
-            (-7.5, 5.0),
-            (7.5, 5.0),
-            (8.5, 6.0),
-            (8.5, -6.0),
-            (-8.5, -6.0),
-            (-8.5, 6.0),
-            (8.5, 6.0),
-        ]
-
-    def test_creation(self):
-        """Creates a rectangular extrusion using the HollowCube
-        parametric component and checks that a cadquery solid is created."""
-
-        assert self.test_shape.solid is not None
-        assert self.test_shape.volume() > 100
-
-    def test_absolute_volume(self):
-        """Creates a rectangular extrusion using the HollowCube
-        parametric component and checks that the volume is correct"""
-
-        assert self.test_shape.volume() == pytest.approx((17 * 12 * 2) - (15 * 10 * 2))
-
-    def test_absolute_areas(self):
-        """Creates a rectangular extrusion using the HollowCube
-        parametric component and checks that the areas are correct"""
-
-        assert len(self.test_shape.areas) == 10
-        assert len(set([round(i) for i in self.test_shape.areas])) == 5
-        assert self.test_shape.areas.count(pytest.approx(15 * 2)) == 2
-        assert self.test_shape.areas.count(pytest.approx(10 * 2)) == 2
+        assert self.test_shape.center_coordinate == (0.0, 0.0, 0.0)
 
     def test_center_point_changes_bounding_box(self):
+        """Checks that moving the center results in the bounding box move as well"""
 
-        default_shape_bb = ((-(15 + 2) / 2, -1.0, -(10 + 2) / 2), ((15 + 2) / 2, 1.0, (10 + 2) / 2))
+        default_shape_bb = ((-(10 + 2) / 2, -(10 + 2) / 2, -(10 + 2) / 2), ((10 + 2) / 2, (10 + 2) / 2, (10 + 2) / 2))
         assert self.test_shape.bounding_box == default_shape_bb
 
-        self.test_shape.center_point = (1, 1)
+        self.test_shape.center_coordinate = (1, 1, 1)
 
         assert self.test_shape.bounding_box == (
-            (default_shape_bb[0][0] + 1, default_shape_bb[0][1], default_shape_bb[0][2] + 1),
-            (default_shape_bb[1][0] + 1, default_shape_bb[1][1], default_shape_bb[1][2] + 1),
+            (default_shape_bb[0][0] + 1, default_shape_bb[0][1] + 1, default_shape_bb[0][2] + 1),
+            (default_shape_bb[1][0] + 1, default_shape_bb[1][1] + 1, default_shape_bb[1][2] + 1),
+        )
+
+        self.test_shape.center_coordinate = (-2, 3, 14)
+
+        assert self.test_shape.bounding_box == (
+            (default_shape_bb[0][0] - 2, default_shape_bb[0][1] + 3, default_shape_bb[0][2] + 14),
+            (default_shape_bb[1][0] - 2, default_shape_bb[1][1] + 3, default_shape_bb[1][2] + 14),
         )

--- a/tests/test_parametric_reactors/test_ball_reactor.py
+++ b/tests/test_parametric_reactors/test_ball_reactor.py
@@ -32,8 +32,8 @@ class TestBallReactor(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 27
-        assert len(self.test_reactor.input_variable_names) == 27
+        assert len(self.test_reactor.input_variables.keys()) == 25
+        assert len(self.test_reactor.input_variable_names) == 25
 
     def test_creation_with_narrow_divertor(self):
         """Creates a BallReactor with a narrow divertor and checks that the correct

--- a/tests/test_parametric_reactors/test_center_column_study_reactor.py
+++ b/tests/test_parametric_reactors/test_center_column_study_reactor.py
@@ -32,8 +32,8 @@ class TestCenterColumnStudyReactor(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 16
-        assert len(self.test_reactor.input_variable_names) == 16
+        assert len(self.test_reactor.input_variables.keys()) == 14
+        assert len(self.test_reactor.input_variable_names) == 14
 
     def test_creation(self):
         """Creates a ball reactor using the CenterColumnStudyReactor parametric_reactor and checks

--- a/tests/test_parametric_reactors/test_eu_demo_2015_reactor.py
+++ b/tests/test_parametric_reactors/test_eu_demo_2015_reactor.py
@@ -12,8 +12,8 @@ class TestDemo2015Reactor(unittest.TestCase):
         """tests that the number of inputs variables is correct"""
 
         my_reactor = paramak.EuDemoFrom2015PaperDiagram(number_of_tf_coils=1)
-        assert len(my_reactor.input_variables.keys()) == 4
-        assert len(my_reactor.input_variable_names) == 4
+        assert len(my_reactor.input_variables.keys()) == 2
+        assert len(my_reactor.input_variable_names) == 2
 
     def test_plasma_construction(self):
         """Creates the plasma part of the EuDemoFrom2015PaperDiagram and checks

--- a/tests/test_parametric_reactors/test_flf_system_code_reactor.py
+++ b/tests/test_parametric_reactors/test_flf_system_code_reactor.py
@@ -28,8 +28,8 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 12
-        assert len(self.test_reactor.input_variable_names) == 12
+        assert len(self.test_reactor.input_variables.keys()) == 10
+        assert len(self.test_reactor.input_variable_names) == 10
 
     def test_stp_file_creation(self):
         """Exports a step file and checks that it was saved successfully"""
@@ -57,11 +57,11 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
 
         my_reactor = paramak.FlfSystemCodeReactor()
 
-        my_reactor.export_brep(filename="without_graveyard.brep", include_graveyard=False)
+        my_reactor.export_brep(filename="without_graveyard.brep", include_graveyard=None)
         brep_shapes = Shape.importBrep("without_graveyard.brep").Solids()
         assert len(brep_shapes) == 6
 
-        my_reactor.export_brep(filename="with_graveyard.brep", include_graveyard=True)
+        my_reactor.export_brep(filename="with_graveyard.brep", include_graveyard={"size": 2000})
         brep_shapes = Shape.importBrep("with_graveyard.brep").Solids()
         assert len(brep_shapes) == 7
 

--- a/tests/test_parametric_reactors/test_iter_reactor.py
+++ b/tests/test_parametric_reactors/test_iter_reactor.py
@@ -12,8 +12,8 @@ class TestITERReactor(unittest.TestCase):
         """tests that the number of inputs variables is correct"""
 
         my_reactor = paramak.IterFrom2020PaperDiagram(number_of_tf_coils=1)
-        assert len(my_reactor.input_variables.keys()) == 4
-        assert len(my_reactor.input_variable_names) == 4
+        assert len(my_reactor.input_variables.keys()) == 2
+        assert len(my_reactor.input_variable_names) == 2
 
     def test_plasma_construction(self):
         """Creates the plasma part of the ITERTokamak and checks

--- a/tests/test_parametric_reactors/test_segmented_blanket_ball_reactor.py
+++ b/tests/test_parametric_reactors/test_segmented_blanket_ball_reactor.py
@@ -37,8 +37,8 @@ class TestSegmentedBlanketBallReactor(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variable is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 30
-        assert len(self.test_reactor.input_variable_names) == 30
+        assert len(self.test_reactor.input_variables.keys()) == 28
+        assert len(self.test_reactor.input_variable_names) == 28
 
     def test_gap_between_blankets_impacts_volume(self):
         """Creates a SegmentedBlanketBallReactor with different

--- a/tests/test_parametric_reactors/test_single_null_ball_reactor.py
+++ b/tests/test_parametric_reactors/test_single_null_ball_reactor.py
@@ -39,8 +39,8 @@ class TestSingleNullBallReactor(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 27
-        assert len(self.test_reactor.input_variable_names) == 27
+        assert len(self.test_reactor.input_variables.keys()) == 25
+        assert len(self.test_reactor.input_variable_names) == 25
 
     def test_single_null_ball_reactor_with_pf_and_tf_coils(self):
         """Checks that a SingleNullBallReactor with optional pf and tf coils can

--- a/tests/test_parametric_reactors/test_single_null_submersion_tokamak.py
+++ b/tests/test_parametric_reactors/test_single_null_submersion_tokamak.py
@@ -40,8 +40,8 @@ class TestSingleNullSubmersionTokamak(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 28
-        assert len(self.test_reactor.input_variable_names) == 28
+        assert len(self.test_reactor.input_variables.keys()) == 26
+        assert len(self.test_reactor.input_variable_names) == 26
 
     def test_single_null_submersion_tokamak_with_pf_and_tf_coils(self):
         """Creates a SingleNullSubmersionTokamak with pf and tf coils and checks

--- a/tests/test_parametric_reactors/test_sparc_2020_reactor.py
+++ b/tests/test_parametric_reactors/test_sparc_2020_reactor.py
@@ -64,8 +64,8 @@ class TestSparc2020Reactor(unittest.TestCase):
     def test_input_variables_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 27
-        assert len(self.test_reactor.input_variable_names) == 27
+        assert len(self.test_reactor.input_variables.keys()) == 25
+        assert len(self.test_reactor.input_variable_names) == 25
 
     def test_make_sparc_2020_reactor(self):
         """Runs the example to check the output files are produced"""

--- a/tests/test_parametric_reactors/test_submersion_tokamak.py
+++ b/tests/test_parametric_reactors/test_submersion_tokamak.py
@@ -32,8 +32,8 @@ class TestSubmersionTokamak(unittest.TestCase):
     def test_input_variable_names(self):
         """tests that the number of inputs variables is correct"""
 
-        assert len(self.test_reactor.input_variables.keys()) == 28
-        assert len(self.test_reactor.input_variable_names) == 28
+        assert len(self.test_reactor.input_variables.keys()) == 26
+        assert len(self.test_reactor.input_variable_names) == 26
 
     def test_svg_creation(self):
         """Creates a SubmersionTokamak and checks that an svg file of the

--- a/tests/test_parametric_shapes/test_extrude_straight_shape.py
+++ b/tests/test_parametric_shapes/test_extrude_straight_shape.py
@@ -23,7 +23,12 @@ class TestExtrudeStraightShape(unittest.TestCase):
     def test_largest_dimension(self):
         """checks the largest dimension value"""
 
-        assert self.test_shape.largest_dimension == 30.0
+        assert self.test_shape.largest_dimension == 25.0
+
+    def get_largest_distance_from_origin(self):
+        """checks the largest dimension from 0,0,0 value"""
+
+        assert self.test_shape.largest_dimension_from == 30.0
 
     def test_translate(self):
         """Checks the shape extends to the bounding box and then translates

--- a/tests/test_parametric_shapes/test_extrude_straight_shape.py
+++ b/tests/test_parametric_shapes/test_extrude_straight_shape.py
@@ -25,11 +25,6 @@ class TestExtrudeStraightShape(unittest.TestCase):
 
         assert self.test_shape.largest_dimension == 25.0
 
-    def get_largest_distance_from_origin(self):
-        """checks the largest dimension from 0,0,0 value"""
-
-        assert self.test_shape.largest_dimension_from == 30.0
-
     def test_translate(self):
         """Checks the shape extends to the bounding box and then translates
         the shape and checks it is extended to the new bounding box"""

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -62,17 +62,16 @@ class TestReactor(unittest.TestCase):
 
     def test_incorrect_graveyard_offset_too_small(self):
         def incorrect_graveyard_offset_too_small():
-            """Set graveyard_offset as a negative number which should raise an error"""
+            """Set graveyard offset as a negative number which should raise an error"""
 
-            self.test_reactor.graveyard_offset = -3
+            self.test_reactor.make_graveyard(offset=-3)
 
         self.assertRaises(ValueError, incorrect_graveyard_offset_too_small)
 
     def test_incorrect_graveyard_offset_wrong_type(self):
         def incorrect_graveyard_offset_wrong_type():
-            """Set graveyard_offset as a string which should raise an error"""
-
-            self.test_reactor.graveyard_offset = "coucou"
+            """Set graveyard offset as a string which should raise an error"""
+            self.test_reactor.make_graveyard(offset="coucou")
 
         self.assertRaises(TypeError, incorrect_graveyard_offset_wrong_type)
 
@@ -80,14 +79,14 @@ class TestReactor(unittest.TestCase):
         """Makes a neutronics model and checks the default largest_dimension
         and that largest_dimension changes with largest_shapes"""
 
-        assert self.test_reactor.largest_dimension == 20.0
+        assert pytest.approx(self.test_reactor.largest_dimension) == 20.0
         assert self.test_reactor_2.largest_dimension == 100.0
 
         test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
         test_shape2 = paramak.RotateStraightShape(points=[(0, 0), (0, 40), (40, 40)])
 
         test_reactor = paramak.Reactor([test_shape, test_shape2])
-        assert test_reactor.largest_dimension == 40
+        assert pytest.approx(test_reactor.largest_dimension) == 40
 
     def test_make_sector_wedge(self):
         """Checks that the wedge is not made when rotation angle is 360"""
@@ -104,7 +103,7 @@ class TestReactor(unittest.TestCase):
 
     def test_make_graveyard_accepts_offset_from_graveyard(self):
         """Creates a graveyard for a reactor and sets the graveyard_offset.
-        Checks that the Reactor.graveyard_offset property is set"""
+        Checks that the Reactor.graveyard property is set"""
 
         test_shape = paramak.RotateStraightShape(
             points=[(0, 0), (0, 20), (20, 20)],
@@ -114,9 +113,10 @@ class TestReactor(unittest.TestCase):
         )
         test_shape.rotation_angle = 360
         test_reactor = paramak.Reactor([test_shape, test_shape2])
-        test_reactor.graveyard_offset == 101
-        graveyard = test_reactor.make_graveyard()
+
+        graveyard = test_reactor.make_graveyard(offset=101)
         assert graveyard.volume() > 0
+        assert test_reactor.graveyard.volume() > 0
 
     def test_reactor_creation_with_default_properties(self):
         """creates a Reactor object and checks that it has no default properties"""
@@ -144,7 +144,7 @@ class TestReactor(unittest.TestCase):
         test_shape.rotation_angle = 360
         test_shape.create_solid()
         test_reactor = paramak.Reactor([test_shape])
-        test_reactor.make_graveyard()
+        test_reactor.make_graveyard(size=100)
 
         assert isinstance(test_reactor.graveyard, paramak.Shape)
 
@@ -158,7 +158,7 @@ class TestReactor(unittest.TestCase):
         test_shape.create_solid()
         test_reactor = paramak.Reactor([test_shape])
         test_reactor.shapes_and_components[0].solid = None
-        test_reactor.make_graveyard()
+        test_reactor.make_graveyard(size=100)
 
         assert isinstance(test_reactor.graveyard, paramak.Shape)
 
@@ -172,14 +172,15 @@ class TestReactor(unittest.TestCase):
         os.system("rm graveyard.stp")
         test_reactor = paramak.Reactor([test_shape])
 
-        test_reactor.export_stp_graveyard()
-        test_reactor.export_stp_graveyard(filename="my_graveyard.stp")
-        test_reactor.export_stp_graveyard(filename="my_graveyard_without_ext")
+        test_reactor.make_graveyard(size=100)
+        test_reactor.graveyard.export_stp(filename="graveyard.stp")
+        test_reactor.graveyard.export_stp(filename="my_graveyard.stp")
+        test_reactor.graveyard.export_stp(filename="my_graveyard_without_ext.step")
 
         for filepath in [
             "graveyard.stp",
             "my_graveyard.stp",
-            "my_graveyard_without_ext.stp",
+            "my_graveyard_without_ext.step",
         ]:
             assert Path(filepath).exists() is True
             os.system("rm " + filepath)
@@ -193,16 +194,16 @@ class TestReactor(unittest.TestCase):
 
         test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
         os.system("rm graveyard.stp")
-        test_reactor = paramak.Reactor([test_shape], graveyard_size=None, graveyard_offset=100)
-        test_reactor.make_graveyard()
+        test_reactor = paramak.Reactor([test_shape])
+        test_reactor.make_graveyard(offset=100)
 
         graveyard_volume_1 = test_reactor.graveyard.volume()
 
-        test_reactor.make_graveyard(graveyard_offset=50)
+        test_reactor.make_graveyard(offset=50)
         assert test_reactor.graveyard.volume() < graveyard_volume_1
         graveyard_volume_2 = test_reactor.graveyard.volume()
 
-        test_reactor.make_graveyard(graveyard_offset=200)
+        test_reactor.make_graveyard(offset=200)
         assert test_reactor.graveyard.volume() > graveyard_volume_1
         assert test_reactor.graveyard.volume() > graveyard_volume_2
 
@@ -385,27 +386,30 @@ class TestReactor(unittest.TestCase):
 
         def incorrect_graveyard_size_size():
             test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
-            paramak.Reactor([test_shape], graveyard_size=-10)
+            test_reactor = paramak.Reactor([test_shape])
+            test_reactor.make_graveyard(size=-10)
 
         self.assertRaises(ValueError, incorrect_graveyard_size_size)
 
     def test_graveyard_offset_setting_type_checking(self):
-        """Attempts to make a reactor with a graveyard_offset that is an float
+        """Attempts to make a reactor with a graveyard offset that is an float
         which should raise a ValueError"""
 
         def incorrect_graveyard_offset_type():
             test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
-            paramak.Reactor([test_shape], graveyard_offset="coucou")
+            test_reactor = paramak.Reactor([test_shape])
+            test_reactor.make_graveyard(offset="coucou")
 
         self.assertRaises(TypeError, incorrect_graveyard_offset_type)
 
     def test_graveyard_offset_setting_magnitude_checking(self):
-        """Attempts to make a reactor with a graveyard_offset that is an int
+        """Attempts to make a reactor with a graveyard offset that is an int
         which should raise a ValueError"""
 
         def incorrect_graveyard_offset_size():
             test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])
-            paramak.Reactor([test_shape], graveyard_offset=-10)
+            test_reactor = paramak.Reactor([test_shape])
+            test_reactor.make_graveyard(size=-10)
 
         self.assertRaises(ValueError, incorrect_graveyard_offset_size)
 
@@ -414,17 +418,17 @@ class TestReactor(unittest.TestCase):
         test_reactor = paramak.Reactor([test_shape])
 
         def str_graveyard_offset():
-            test_reactor.graveyard_offset = "coucou"
+            test_reactor.make_graveyard(offset="coucou")
 
         self.assertRaises(TypeError, str_graveyard_offset)
 
         def negative_graveyard_offset():
-            test_reactor.graveyard_offset = -2
+            test_reactor.make_graveyard(offset=-2)
 
         self.assertRaises(ValueError, negative_graveyard_offset)
 
         def list_graveyard_offset():
-            test_reactor.graveyard_offset = [1.2]
+            test_reactor.make_graveyard(offset=[1.2])
 
         self.assertRaises(TypeError, list_graveyard_offset)
 
@@ -437,7 +441,7 @@ class TestReactor(unittest.TestCase):
         assert test_reactor.solid is not None
 
     def test_sector_wedge_with_360_returns_none(self):
-        """Trys to make a sector wedge with full 360 degree rotation and checks
+        """Tries to make a sector wedge with full 360 degree rotation and checks
         that None is returned"""
 
         test_shape = paramak.RotateStraightShape(points=[(0, 0), (0, 20), (20, 20)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from paramak.utils import (
     find_radius_of_circle,
     get_bounding_box,
     get_largest_dimension,
+    get_largest_distance_from_origin,
 )
 import cadquery as cq
 
@@ -81,13 +82,21 @@ class TestUtilityFunctions(unittest.TestCase):
 
         largest_dimension = get_largest_dimension(test_sphere)
 
+        assert largest_dimension == 20
+
+    def test_largest_dimension__from_origin_with_single_solid_at_origin(self):
+
+        test_sphere = cq.Workplane("XY").moveTo(0, 0).sphere(10)
+
+        largest_dimension = get_largest_distance_from_origin(test_sphere)
+
         assert largest_dimension == 10
 
     def test_largest_dimension_with_single_solid(self):
 
         test_sphere = cq.Workplane("XY").moveTo(100, 0).sphere(10)
 
-        largest_dimension = get_largest_dimension(test_sphere)
+        largest_dimension = get_largest_distance_from_origin(test_sphere)
 
         assert largest_dimension == 110
 
@@ -98,7 +107,7 @@ class TestUtilityFunctions(unittest.TestCase):
 
         both_shapes = cq.Compound.makeCompound([test_sphere_1.val(), test_sphere_2.val()])
 
-        largest_dimension = get_largest_dimension(both_shapes)
+        largest_dimension = get_largest_distance_from_origin(both_shapes)
 
         assert largest_dimension == 210
 

--- a/tests_h5m/test_reactor_export_h5m.py
+++ b/tests_h5m/test_reactor_export_h5m.py
@@ -25,7 +25,6 @@ class TestReactor(unittest.TestCase):
 
         # this reactor has a compound shape in the geometry
         self.test_reactor_3 = paramak.Reactor([self.test_shape, test_shape_3])
-        self.test_reactor_3.graveyard_size = 250
 
     def test_dagmc_h5m_custom_tags_export(self):
         """Exports a reactor with two shapes checks that the tags are correctly
@@ -74,7 +73,9 @@ class TestReactor(unittest.TestCase):
         named in the resulting h5m file, includes the optional graveyard"""
 
         self.test_reactor_3.rotation_angle = 180
-        self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", tags=["1", "2", "grave"], include_graveyard=True)
+        self.test_reactor_3.export_dagmc_h5m(
+            "dagmc_reactor.h5m", tags=["1", "2", "grave"], include_graveyard={"size": 250}
+        )
 
         vols = di.get_volumes_from_h5m("dagmc_reactor.h5m")
         assert vols == [1, 2, 3, 4]
@@ -96,7 +97,7 @@ class TestReactor(unittest.TestCase):
         named in the resulting h5m file, includes the optional graveyard"""
 
         self.test_reactor_3.rotation_angle = 180
-        self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", include_graveyard=True)
+        self.test_reactor_3.export_dagmc_h5m("dagmc_reactor.h5m", include_graveyard={"size": 250})
 
         vols = di.get_volumes_from_h5m("dagmc_reactor.h5m")
         assert vols == [1, 2, 3, 4]


### PR DESCRIPTION
## Proposed changes

Refactoring the method of making the graveyard so that it can be centered around the center of the geometry

Reactor.export_dagmc_h5m(filename="dagmc.h5m", include_graveyard={'offset':10})

Reactor.export_dagmc_h5m(filename="dagmc.h5m", include_graveyard={'size':2000})

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [x] New tests

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
