### PR TITLE
removed vacuum from name

### DIFF
--- a/examples/example_parametric_reactors/render_of_random_reactor_render_gif.py
+++ b/examples/example_parametric_reactors/render_of_random_reactor_render_gif.py
@@ -48,11 +48,11 @@ def create_reactor_renders(
     # assigns colours to each stl file
     stl_files_with_colors = {
         "blanket.stl": (255, 255, 0),
-        "vacuum_vessel.stl": (128, 128, 128),
+        "vessel.stl": (128, 128, 128),
         "upper_blanket.stl": (255, 255, 0),
         "lower_blanket.stl": (255, 255, 0),
-        "lower_vacuum_vessel.stl": (128, 128, 128),
-        "upper_vacuum_vessel.stl": (128, 128, 128),
+        "lower_vessel.stl": (128, 128, 128),
+        "upper_vessel.stl": (128, 128, 128),
     }
 
     scene = pyrender.Scene()

--- a/paramak/parametric_components/constant_thickness_dome.py
+++ b/paramak/parametric_components/constant_thickness_dome.py
@@ -116,7 +116,10 @@ class ConstantThicknessDome(RotateMixedShape):
         #       far side
 
         if self.chord_height * 2 >= self.chord_width:
-            msg = "ConstantThicknessDome requires that the self.chord_width is at least 2 times as large as the chord height"
+            msg = (
+                "ConstantThicknessDome requires that the self.chord_width "
+                "is at least 2 times as large as the chord height"
+            )
             raise ValueError(msg)
 
         radius_of_sphere = ((math.pow(self.chord_width, 2)) + (4.0 * math.pow(self.chord_height, 2))) / (

--- a/paramak/parametric_components/dished_vacuum_vessel.py
+++ b/paramak/parametric_components/dished_vacuum_vessel.py
@@ -23,7 +23,7 @@ class DishedVacuumVessel(RotateMixedShape):
         dish_height: float = 50,
         cylinder_height: float = 400,
         thickness: float = 15,
-        name: str = "dished_vacuum_vessel",
+        name: str = "dished_vessel",
         **kwargs,
     ):
         self.radius = radius

--- a/paramak/parametric_reactors/flf_system_code_reactor.py
+++ b/paramak/parametric_reactors/flf_system_code_reactor.py
@@ -90,7 +90,7 @@ class FlfSystemCodeReactor(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             color=(0.5, 0.5, 0.5),
-            name="lower_vacuum_vessel",
+            name="lower_vessel",
         )
 
         lower_blanket = paramak.RotateStraightShape(
@@ -137,7 +137,7 @@ class FlfSystemCodeReactor(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             color=(0.5, 0.5, 0.5),
-            name="upper_vacuum_vessel",
+            name="upper_vessel",
         )
 
         upper_blanket = paramak.RotateStraightShape(
@@ -201,7 +201,7 @@ class FlfSystemCodeReactor(paramak.Reactor):
             ],
             rotation_angle=self.rotation_angle,
             color=(0.5, 0.5, 0.5),
-            name="vacuum_vessel",
+            name="vessel",
         )
 
         self.shapes_and_components = [

--- a/paramak/parametric_reactors/negative_triangularity_reactor.py
+++ b/paramak/parametric_reactors/negative_triangularity_reactor.py
@@ -744,7 +744,7 @@ class NegativeTriangularityReactor(paramak.Reactor):
             inner_radius=self._vacuum_vessel_inwall_start_rad,
             outer_radius=self._vacuum_vessel_inwall_end_rad,
             rotation_angle=self._rotation_angle,
-            name="vacuum_vessel_inner_wall",
+            name="vessel_inner_wall",
             color=(0.5, 0.5, 0.5),
             cut=[self._pf_coils, self._pf_casing],
         )
@@ -896,7 +896,7 @@ class NegativeTriangularityReactor(paramak.Reactor):
             inner_radius=self._vacuum_vessel_inwall_start_rad,
             outer_radius=self._vacuum_vessel_body_end_rad,
             rotation_angle=self._rotation_angle,
-            name="vacuum_vessel_body",
+            name="vessel_body",
             cut=cutting_list,
             color=(0.5, 0.5, 0.5),
         )

--- a/paramak/reactor.py
+++ b/paramak/reactor.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from logging import warning
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 

--- a/paramak/shape.py
+++ b/paramak/shape.py
@@ -278,7 +278,11 @@ class Shape:
                     raise ValueError(msg)
                 for val in point:
                     if not isinstance(val, (int, float)):
-                        msg = f"Shape.rotation_axis should be an iterable of iterables where the nested iterables are numerical, not {type(val)}"
+                        msg = (
+                            "Shape.rotation_axis should be an iterable of "
+                            "iterables where the nested iterables are "
+                            f"numerical, not {type(val)}"
+                        )
                         raise ValueError(msg)
 
             if value[0] == value[1]:

--- a/tests/test_parametric_reactors/test_flf_system_code_reactor.py
+++ b/tests/test_parametric_reactors/test_flf_system_code_reactor.py
@@ -49,7 +49,7 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
         assert Path("blanket.stp").is_file()
         assert Path("upper_blanket.stp").is_file()
         assert Path("upper_vessel.stp").is_file()
-        assert Path("vacuum_vessel.stp").is_file()
+        assert Path("vessel.stp").is_file()
 
     def test_graveyard_volume_in_brep_export(self):
         """Exports the reactor as a brep file and checks the number of volumes
@@ -79,7 +79,7 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
 
         assert self.test_reactor.name == [
             "blanket",
-            "vacuum_vessel",
+            "vessel",
             "upper_blanket",
             "lower_blanket",
             "lower_vessel",

--- a/tests/test_parametric_reactors/test_flf_system_code_reactor.py
+++ b/tests/test_parametric_reactors/test_flf_system_code_reactor.py
@@ -44,11 +44,11 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
 
         os.system("rm *.stp")
         self.test_reactor.export_stp()
-        assert Path("lower_vacuum_vessel.stp").is_file()
+        assert Path("lower_vessel.stp").is_file()
         assert Path("lower_blanket.stp").is_file()
         assert Path("blanket.stp").is_file()
         assert Path("upper_blanket.stp").is_file()
-        assert Path("upper_vacuum_vessel.stp").is_file()
+        assert Path("upper_vessel.stp").is_file()
         assert Path("vacuum_vessel.stp").is_file()
 
     def test_graveyard_volume_in_brep_export(self):
@@ -82,8 +82,8 @@ class TestFlfSystemCodeReactor(unittest.TestCase):
             "vacuum_vessel",
             "upper_blanket",
             "lower_blanket",
-            "lower_vacuum_vessel",
-            "upper_vacuum_vessel",
+            "lower_vessel",
+            "upper_vessel",
         ]
 
     def test_blanket_volume_against_analytical_volume(self):

--- a/tests/test_parametric_shapes/test_extrude_mixed_shape.py
+++ b/tests/test_parametric_shapes/test_extrude_mixed_shape.py
@@ -190,7 +190,8 @@ class TestExtrudeMixedShape(unittest.TestCase):
         assert self.test_shape_2.processed_points[-4] == (150, 100, "straight")
         assert self.test_shape_2.processed_points[-5] == (200, 100, "straight")
 
-        for point in self.test_shape_2.processed_points[1 : len(self.test_shape_2.points) - 5]:
+        spline_points = len(self.test_shape_2.points) - 5
+        for point in self.test_shape_2.processed_points[1:spline_points]:
             assert point[2] == "spline"
 
     def test_convert_circles_to_splines_volume(self):


### PR DESCRIPTION
## Proposed changes

This PR removes the word "vacuum" from the name of components.
so componets like "vacuum_vessel" have been renamed "vessel"
This is useful as the name of components is used when making DAGMC tags
DAGMC tags including the word vacuum anywhere in the tag will treat the material as a vacuum. 
https://github.com/svalinn/DAGMC/issues/805#issuecomment-1104291031

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
