### PR TITLE
saved time by not writting brep file

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - mpmath
     - plasmaboundaries >=0.1.8
     - plotly
-    - brep_part_finder >=0.4.2 # [not win]
+    - brep_part_finder >=0.4.4 # [not win]
     - brep_to_h5m >=0.3.1 # [not win]
     - moab * nompi_tempest_*
     # - jupyter-cadquery not available on conda

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - mpmath
     - plasmaboundaries >=0.1.8
     - plotly
-    - brep_part_finder >=0.4.1 # [not win]
+    - brep_part_finder >=0.4.2 # [not win]
     - brep_to_h5m >=0.3.1 # [not win]
     - moab * nompi_tempest_*
     # - jupyter-cadquery not available on conda

--- a/paramak/utils.py
+++ b/paramak/utils.py
@@ -111,7 +111,6 @@ def export_solids_to_dagmc_h5m(
     # saves the reactor as a Brep file with merged surfaces
     brep_shape = export_solids_to_brep_object(solids=solids)
 
-    # brep file is imported
     brep_file_part_properties = bpf.get_brep_part_properties_from_shape(brep_shape)
 
     if verbose:
@@ -159,6 +158,10 @@ def export_solids_to_dagmc_h5m(
 
     if verbose:
         print(f"key_and_part_id={key_and_part_id}")
+
+    # gmsh requires an actual brep file to load
+    tmp_brep_filename = mkstemp(suffix=".brep", prefix="paramak_")[1]
+    brep_shape.exportBrep(tmp_brep_filename)
 
     brep_to_h5m(
         brep_filename=tmp_brep_filename,

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires=
     plasmaboundaries >= 0.1.8
     jupyter-client < 7
     jupyter-cadquery >= 3.2.0
-    brep_part_finder >= 0.4.2
+    brep_part_finder >= 0.4.4
     brep_to_h5m >= 0.3.1
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires=
     plasmaboundaries >= 0.1.8
     jupyter-client < 7
     jupyter-cadquery >= 3.2.0
-    brep_part_finder >= 0.4.1
+    brep_part_finder >= 0.4.2
     brep_to_h5m >= 0.3.1
     setuptools_scm
 


### PR DESCRIPTION
brep_part_finder package can make use of a brep object as well as a brep file

There is an opportunity to save a bit of time by not writing out an intermediate brep file when making a dagmc file as we can simply return the brep object and skip the file writing and reading