### PR TITLE
Addition of the ability to produce mutilayer firstwalls

### DIFF
--- a/src/paramak/parametric_reactors/submersion_reactor.py
+++ b/src/paramak/parametric_reactors/submersion_reactor.py
@@ -60,7 +60,7 @@ class SubmersionTokamak(paramak.Reactor):
         inboard_tf_leg_radial_thickness: float = 30,
         center_column_shield_radial_thickness: float = 30,
         inboard_blanket_radial_thickness: float = 80,
-        firstwall_radial_thickness: Union[float, list[float]] = 20,
+        firstwall_radial_thickness: Union[float, List[float]] = 20,
         inner_plasma_gap_radial_thickness: float = 50,
         plasma_radial_thickness: float = 200,
         divertor_radial_thickness: float = 80,


### PR DESCRIPTION
## Proposed changes

Aims to solve #302 . Adding the ability to create multilayer first walls. I've initially only created this for the submersion reactor, but the code is easily ported to the other reactor types if this is something seen as useful. 

For the user the reactor will work identical to before is the firstwall_radial_thickness parameter is set as a float. If a list of floats, the first wall will be composed of layers with each item as a thickness: 

`firstwall_radial_thickness = [10,5,20]`

I think the only reactor type that may require additional work for including is the segmented blanket reactor as the first wall wraps the sides of the blanket. It is likely you would not want multiple layers wrapping the blanket, but potentially just the last layer.

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
