### PR TITLE
Special case for 360 sphere

### DIFF
--- a/src/paramak/parametric_components/spherical_shell.py
+++ b/src/paramak/parametric_components/spherical_shell.py
@@ -1,7 +1,8 @@
 from typing import Optional, Tuple
 
-from paramak import RotateMixedShape
+from paramak import RotateMixedShape, Shape
 from paramak.utils import patch_workplane
+import cadquery as cq
 
 patch_workplane()
 
@@ -93,3 +94,21 @@ class SphericalShell(RotateMixedShape):
                 (0, self.inner_radius, "circle"),
                 (self.inner_radius, 0, "circle"),
             ]
+
+    def create_solid(self):
+        """Creates a extruded 3d solid using points with circular edges.
+
+        Returns:
+           A CadQuery solid: A 3D solid volume
+        """
+
+        if self.rotation_angle == 360.0:
+            "The prevents a 360 sphere from getting additional surfaces from the rotation"
+            self.solid = (
+                cq.Workplane()
+                .sphere(self.inner_radius + self.shell_thickness)
+                .cut(cq.Workplane().sphere(self.inner_radius))
+            )
+            return self
+        else:
+            return super().create_solid()

--- a/tests/tests_units/test_parametric_components/test_spherical_shell.py
+++ b/tests/tests_units/test_parametric_components/test_spherical_shell.py
@@ -5,10 +5,7 @@ import paramak
 
 class TestSphericalShell(unittest.TestCase):
     def setUp(self):
-        self.test_shape = paramak.SphericalShell(
-            inner_radius=1,
-            shell_thickness=0.2,
-        )
+        self.test_shape = paramak.SphericalShell(inner_radius=1, shell_thickness=0.2, rotation_angle=180)
 
     def test_volume(self):
         """Creates a shape wit different roation angles and checks the volume."""
@@ -35,3 +32,17 @@ class TestSphericalShell(unittest.TestCase):
 
         self.test_shape.rotation_angle = 360
         assert self.test_shape.solid is not None
+
+    def test_surfaces(self):
+        """Creates a shape and checks that a cadquery solid is created.
+        Different rotation angles are used as we have special case handling
+        for the 360 degree case"""
+
+        self.test_shape.rotation_angle = 180
+        assert len(self.test_shape.solid.faces().all()) == 3
+
+        self.test_shape.rotation_angle = 360
+        assert len(self.test_shape.solid.faces().all()) == 2
+
+        self.test_shape.rotation_angle = 270
+        assert len(self.test_shape.solid.faces().all()) == 4

--- a/tests/tests_units/test_parametric_components/test_spherical_shell.py
+++ b/tests/tests_units/test_parametric_components/test_spherical_shell.py
@@ -1,14 +1,37 @@
 import unittest
-
+import math
 import paramak
 
 
 class TestSphericalShell(unittest.TestCase):
     def setUp(self):
-        self.test_shape = paramak.SphericalShell(inner_radius=1, shell_thickness=0.2)
+        self.test_shape = paramak.SphericalShell(
+            inner_radius=1,
+            shell_thickness=0.2,
+        )
+
+    def test_volume(self):
+        """Creates a shape wit different roation angles and checks the volume."""
+        vol1 = (4 / 3) * math.pi * math.pow(self.test_shape.inner_radius, 3)
+        vol2 = (4 / 3) * math.pi * math.pow(self.test_shape.inner_radius + self.test_shape.shell_thickness, 3)
+        full_vol = vol2 - vol1
+
+        self.test_shape.rotation_angle = 180
+        assert math.isclose(0.5 * full_vol, self.test_shape.volume())
+
+        self.test_shape.rotation_angle = 360
+        assert math.isclose(full_vol, self.test_shape.volume())
+
+        self.test_shape.rotation_angle = 270
+        assert math.isclose(0.75 * full_vol, self.test_shape.volume())
 
     def test_creation(self):
-        """Creates a shape using the VacuumVessel parametric component and
-        checks that a cadquery solid is created."""
+        """Creates a shape and checks that a cadquery solid is created.
+        Different rotation angles are used as we have special case handling
+        for the 360 degree case"""
 
+        self.test_shape.rotation_angle = 180
+        assert self.test_shape.solid is not None
+
+        self.test_shape.rotation_angle = 360
         assert self.test_shape.solid is not None


### PR DESCRIPTION
@generein I had a quick look at issue #305 and wonder if we need a special case for the 360 degree sphere.

I've modified your original class to have a special route for the 360 degree rotated sphere

I've also added a few more tests to check volumes and number of faces on the result

I have not yet run this through the neutronics workflow, any chance you could test it for your use case