### PR TITLE
Fixing pip install . in ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,18 +46,18 @@ RUN apt-get --allow-releaseinfo-change update
 RUN apt-get update -y && \
     apt-get upgrade -y
 
-RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev  freeglut3-dev libosmesa6 libosmesa6-dev  libgles2-mesa-dev curl imagemagick && \
-                       apt-get clean
+# RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev  freeglut3-dev libosmesa6 libosmesa6-dev  libgles2-mesa-dev curl imagemagick && \
+#                        apt-get clean
 
-# Installing CadQuery and Gmsh
-RUN echo installing CadQuery version $cq_version && \
-    conda install -c conda-forge -c python python=3.8 && \
-    conda install -c conda-forge -c cadquery cadquery="$cq_version" && \
-    conda install -c conda-forge moab && \
-    conda install -c conda-forge gmsh && \
-    conda install -c conda-forge python-gmsh && \
-    pip install jupyter-cadquery && \
-    conda clean -afy
+# # Installing CadQuery and Gmsh
+# RUN echo installing CadQuery version $cq_version && \
+#     conda install -c conda-forge -c python python=3.8 && \
+#     conda install -c conda-forge -c cadquery cadquery="$cq_version" && \
+#     conda install -c conda-forge moab && \
+#     conda install -c conda-forge gmsh && \
+#     conda install -c conda-forge python-gmsh && \
+#     pip install jupyter-cadquery && \
+#     conda clean -afy
 
 
 RUN mkdir /home/paramak
@@ -66,8 +66,6 @@ WORKDIR /home/paramak
 
 
 FROM dependencies as final
-
-ARG paramak_version=develop
 
 COPY run_tests.sh run_tests.sh
 COPY src src/
@@ -78,7 +76,9 @@ COPY pyproject.toml pyproject.toml
 COPY README.md README.md
 COPY LICENSE.txt LICENSE.txt
 
-
-RUN pip install .[tests,docs]
+ARG paramak_version=1.0.0
+# SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK is used to allow versioning
+# https://github.com/pypa/setuptools_scm/blob/main/README.rst#usage-from-docker
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK=${paramak_version} pip install .[tests,docs]
 
 CMD ["jupyter", "lab", "--notebook-dir=/home/paramak/examples", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,6 @@ COPY README.md README.md
 COPY LICENSE.txt LICENSE.txt
 
 
-RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK=${paramak_version} pip install .[tests,docs]
+RUN pip install .[tests,docs]
 
 CMD ["jupyter", "lab", "--notebook-dir=/home/paramak/examples", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/gui.Dockerfile
+++ b/gui.Dockerfile
@@ -22,7 +22,7 @@
 
 
 FROM continuumio/miniconda3:4.9.2 as dependencies
-# 
+#
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=master
 
@@ -59,7 +59,7 @@ COPY README.md paramak/README.md
 COPY LICENSE.txt paramak/LICENSE.txt
 
 RUN cd paramak && \
-    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK=${paramak_version} pip install .[gui]
+    pip install .[gui]
 
 ENV PORT 8501
 

--- a/gui.Dockerfile
+++ b/gui.Dockerfile
@@ -21,7 +21,7 @@
 # docker run -p 8050:8050 paramak_gui
 
 
-FROM continuumio/miniconda3:4.9.2 as dependencies
+FROM continuumio/miniconda3:4.12.0 as dependencies
 #
 # By default this Dockerfile builds with the latest release of CadQuery 2
 ARG cq_version=master
@@ -49,8 +49,6 @@ RUN echo installing CadQuery version $cq_version && \
 
 FROM dependencies as install
 
-ARG paramak_version=develop
-
 RUN mkdir paramak
 COPY src paramak/src/
 COPY pyproject.toml paramak/pyproject.toml
@@ -58,8 +56,11 @@ COPY pyproject.toml paramak/pyproject.toml
 COPY README.md paramak/README.md
 COPY LICENSE.txt paramak/LICENSE.txt
 
+ARG paramak_version=1.0.0
+# SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK is used to allow versioning
+# https://github.com/pypa/setuptools_scm/blob/main/README.rst#usage-from-dockerZ
 RUN cd paramak && \
-    pip install .[gui]
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PARAMAK=${paramak_version} pip install .[tests,docs]
 
 ENV PORT 8501
 


### PR DESCRIPTION
USage of setuptools_scm within docker no longer has access to the .git folder and therefore has trouble finding the version

setting the ```paramak_version``` is the work around

as advised in the [docs](https://github.com/pypa/setuptools_scm/blob/main/README.rst#usage-from-dockerZ)

It looks like "develop" is no longer an acceptable version number so I've changed it to "1.0.0"
