### PR TITLE
docs: add cutting wedge to documentation

### DIFF
--- a/docs/source/API-Reference.rst
+++ b/docs/source/API-Reference.rst
@@ -716,6 +716,19 @@ Cutting Tools
 CuttingWedge()
 ^^^^^^^^^^^^^^
 
+.. cadquery::
+   :select: cadquery_object
+   :gridsize: 0
+
+   import paramak
+   my_component = paramak.CuttingWedge(
+      height=10.0,
+      radius=10.0,
+      rotation_angle=270
+   )
+
+   cadquery_object = my_component.solid
+
 |CuttingWedgestp| |CuttingWedgesvg|
 
 .. |CuttingWedgestp| image:: https://user-images.githubusercontent.com/8583900/94726081-a678c180-0354-11eb-93f2-98d4b4a6839e.png


### PR DESCRIPTION
## Proposed changes

This PR adds CuttingWedge 3d interactive shape to the documentation.
This is one of the many PRs that will be needed to close issue https://github.com/fusion-energy/paramak/issues/30
I tried to run the build test and it's working well. However, I can't see the 3d interactive shape rendered on my local and looks like the sphinx template is somehow different from the live website (I use sphinx `v7.0.1`)

## Types of changes

What types of changes does your code introduce to the Paramak?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [x] Documentation Update (if none of the other choices apply)
- [ ] New tests

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Pep8 applied
- [ ] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
