### PR TITLE
pinning version of cad-to-dagmc to >0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "plasmaboundaries>=0.1.8",
     "jupyter-client<7",
     "jupyter-cadquery>=3.2.0",
-    "cad_to_dagmc>=0.1.2",
+    "cad_to_dagmc>=0.5.0",
     "setuptools_scm[toml]>=7.0.5"
 ]
 


### PR DESCRIPTION
cad-to-dagmc has been updated and it fixes a critcal bug so we should make use of it