### PR TITLE
update for latest c2d api

### DIFF
--- a/src/paramak/utils.py
+++ b/src/paramak/utils.py
@@ -97,7 +97,7 @@ def export_solids_to_dagmc_h5m(
 
     my_model = CadToDagmc()
 
-    my_model.add_cadquery_object(object=solids, material_tags=tags)
+    my_model.add_cadquery_object(cadquery_object=solids, material_tags=tags)
 
     my_model.export_dagmc_h5m_file(max_mesh_size=max_mesh_size, min_mesh_size=min_mesh_size, filename=filename)
 


### PR DESCRIPTION
The cad_to_dagmc API changed a bit and the first arg is called ```cadquery_object``` instead of ```object```

updating code to match the latest api