### PR TITLE
removing libgl1-mesa-glx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
 
       - name: install dependencies run tests
         shell: bash -el {0}
+        env:
+          PATH: "/openmc_venv/bin:$PATH"
         run: |
+          python3 -m venv openmc_venv
           python -m pip install .[tests]
         
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           PATH: "/openmc_venv/bin:$PATH"
         run: |
-          python3 -m venv openmc_venv
+          python -m venv openmc_venv
           python -m pip install .[tests]
         
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
+          sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
 
       - name: checkout actions
         uses: actions/checkout@v4

--- a/.github/workflows/documentation_update.yml
+++ b/.github/workflows/documentation_update.yml
@@ -37,7 +37,10 @@ jobs:
           post-cleanup: 'all'
 
       - name: install package
+        env:
+          PATH: "/openmc_venv/bin:$PATH"
         run: |
+          python3 -m venv openmc_venv
           pip install --upgrade pip
           pip install .[docs]
       - name: Sphinx build tagged version

--- a/.github/workflows/documentation_update.yml
+++ b/.github/workflows/documentation_update.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
+          sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
 
 
       - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/documentation_update.yml
+++ b/.github/workflows/documentation_update.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           PATH: "/openmc_venv/bin:$PATH"
         run: |
-          python3 -m venv openmc_venv
+          python -m venv openmc_venv
           pip install --upgrade pip
           pip install .[docs]
       - name: Sphinx build tagged version


### PR DESCRIPTION
looks like ubuntu latest has changed so the package is no longer found

however it looks like a virtual env is now needed for python
https://github.com/openmc-dev/openmc/blob/8263f05e7ed62290a1a3891ea9ff81f05b13f955/Dockerfile#L78-L79