### PR TITLE
added paramak.Assembly class that inherits from cq.Assembly and adds convenient methods 

### DIFF
--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -28,18 +28,3 @@ class Assembly(cq.Assembly):
         for part in self:
             names.append(part[1].split('/')[-1])
         return names
-
-
-
-
-# testing
-# sphere1 = cq.Workplane().moveTo(2, 2).sphere(1)
-# box1 = cq.Workplane().box(1, 1, 1)
-# assembly = Assembly()
-# assembly.add(box1, name="box1", color=cq.Color(0.5, 0.5, 0.5))
-# assembly.add(sphere1, name="sphere")
-
-
-# assembly2 = assembly.remove('sphere')
-# assembly3 = assembly.remove('box1')
-# assembly4 = assembly.remove('bosdfsdf')

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -8,20 +8,13 @@ import cadquery as cq
 class Assembly(cq.Assembly):
     """Nested assembly of Workplane and Shape objects defining their relative positions."""
 
-    def __init__(self, elongation=None, triangularity=None, major_radius=None, minor_radius=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.elongation = elongation
-        self.triangularity = triangularity
-        self.major_radius = major_radius
-        self.minor_radius = minor_radius
+    elongation=None
+    triangularity=None
+    major_radius=None
+    minor_radius=None
 
     def remove(self, name: str):
-        new_assembly = Assembly(
-            elongation=self.elongation,
-            triangularity=self.triangularity,
-            major_radius=self.major_radius,
-            minor_radius=self.minor_radius
-        )
+        new_assembly = Assembly()
         part_found = False
         for part in self:
             if part[1].endswith(f'/{name}'):
@@ -32,6 +25,11 @@ class Assembly(cq.Assembly):
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')
+        # if hasattr(self, 'elongation'):
+        new_assembly.elongation = self.elongation
+        new_assembly.triangularity = self.triangularity
+        new_assembly.major_radius = self.major_radius
+        new_assembly.minor_radius = self.minor_radius
         return new_assembly
 
     def names(self):

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -20,7 +20,6 @@ class Assembly(cq.Assembly):
             if part[1].endswith(f'/{name}'):
                 part_found = True
             else:
-                # print('adding' , part)
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -25,7 +25,7 @@ class Assembly(cq.Assembly):
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')
-        # if hasattr(self, 'elongation'):
+
         new_assembly.elongation = self.elongation
         new_assembly.triangularity = self.triangularity
         new_assembly.major_radius = self.major_radius

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -19,7 +19,6 @@ class Assembly(cq.Assembly):
         for part in self:
             if part[1].endswith(f'/{name}'):
                 part_found = True
-                # print('removing' , part)
             else:
                 # print('adding' , part)
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -1,0 +1,45 @@
+# Creates an assembly class that inherits from cadquery's assembly class
+# and adds a few conveniences methods remove() and names()
+
+import warnings
+import cadquery as cq
+
+
+class Assembly(cq.Assembly):
+    """Nested assembly of Workplane and Shape objects defining their relative positions."""
+
+    def remove(self, name:str):
+        new_assembly = Assembly()
+        part_found=False
+        for part in self:
+            if part[1].endswith(f'/{name}'):
+                part_found = True
+                # print('removing' , part)
+            else:
+                # print('adding' , part)
+                new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
+        if part_found == False:
+            warnings.warn(f'Part with name {name} not found')
+        return new_assembly
+
+
+    def names(self):
+        names = []
+        for part in self:
+            names.append(part[1].split('/')[-1])
+        return names
+
+
+
+
+# testing
+# sphere1 = cq.Workplane().moveTo(2, 2).sphere(1)
+# box1 = cq.Workplane().box(1, 1, 1)
+# assembly = Assembly()
+# assembly.add(box1, name="box1", color=cq.Color(0.5, 0.5, 0.5))
+# assembly.add(sphere1, name="sphere")
+
+
+# assembly2 = assembly.remove('sphere')
+# assembly3 = assembly.remove('box1')
+# assembly4 = assembly.remove('bosdfsdf')

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -8,9 +8,21 @@ import cadquery as cq
 class Assembly(cq.Assembly):
     """Nested assembly of Workplane and Shape objects defining their relative positions."""
 
-    def remove(self, name:str):
-        new_assembly = Assembly()
-        part_found=False
+    def __init__(self, elongation=None, triangularity=None, major_radius=None, minor_radius=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.elongation = elongation
+        self.triangularity = triangularity
+        self.major_radius = major_radius
+        self.minor_radius = minor_radius
+
+    def remove(self, name: str):
+        new_assembly = Assembly(
+            elongation=self.elongation,
+            triangularity=self.triangularity,
+            major_radius=self.major_radius,
+            minor_radius=self.minor_radius
+        )
+        part_found = False
         for part in self:
             if part[1].endswith(f'/{name}'):
                 part_found = True
@@ -18,10 +30,9 @@ class Assembly(cq.Assembly):
             else:
                 # print('adding' , part)
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
-        if part_found == False:
+        if not part_found:
             warnings.warn(f'Part with name {name} not found')
         return new_assembly
-
 
     def names(self):
         names = []

--- a/src/paramak/assemblies/spherical_tokamak.py
+++ b/src/paramak/assemblies/spherical_tokamak.py
@@ -289,4 +289,7 @@ def spherical_tokamak(
 
     my_assembly.elongation = elongation
     my_assembly.triangularity = triangularity
+    my_assembly.major_radius = major_radius
+    my_assembly.minor_radius = minor_radius
+
     return my_assembly

--- a/src/paramak/assemblies/spherical_tokamak.py
+++ b/src/paramak/assemblies/spherical_tokamak.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Tuple, Union
 
 import cadquery as cq
+from .assembly import Assembly
 
 from ..utils import (
     get_plasma_index,
@@ -235,7 +236,7 @@ def spherical_tokamak(
         center_column=blanket_cutting_cylinder,
     )
 
-    my_assembly = cq.Assembly()
+    my_assembly = Assembly()
 
     for i, entry in enumerate(extra_cut_shapes):
 

--- a/src/paramak/assemblies/spherical_tokamak.py
+++ b/src/paramak/assemblies/spherical_tokamak.py
@@ -111,7 +111,7 @@ def spherical_tokamak_from_plasma(
     extra_cut_shapes: Sequence[cq.Workplane] = [],
     extra_intersect_shapes: Sequence[cq.Workplane] = [],
     colors: dict = {},
-):
+) -> Assembly:
     """Creates a spherical tokamak fusion reactor from a radial build and plasma parameters.
 
 
@@ -169,7 +169,7 @@ def spherical_tokamak(
     extra_cut_shapes: Sequence[cq.Workplane] = [],
     extra_intersect_shapes: Sequence[cq.Workplane] = [],
     colors: dict = {},
-):
+) -> Assembly:
     """  Creates a spherical tokamak fusion reactor from a radial build and vertical build.
 
     Args:
@@ -287,4 +287,6 @@ def spherical_tokamak(
 
     my_assembly.add(plasma, name="plasma", color=cq.Color(*colors.get("plasma", (0.5,0.5,0.5))))
 
+    my_assembly.elongation = elongation
+    my_assembly.triangularity = triangularity
     return my_assembly

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -34,7 +34,7 @@ def create_center_column_shield_cylinders(radial_build, rotation_angle, center_c
 
     number_of_cylinder_layers = count_cylinder_layers(radial_build)
 
-    for index, item in enumerate(radial_build):
+    for _, item in enumerate(radial_build):
         if item[0] == LayerType.PLASMA:
             break
 
@@ -158,7 +158,7 @@ def tokamak_from_plasma(
     extra_cut_shapes: Sequence[cq.Workplane] = [],
     extra_intersect_shapes: Sequence[cq.Workplane] = [],
     colors: dict = {}
-):
+) -> Assembly:
     """
     Creates a tokamak fusion reactor from a radial build and plasma parameters.
 
@@ -217,7 +217,7 @@ def tokamak(
     extra_cut_shapes: Sequence[cq.Workplane] = [],
     extra_intersect_shapes: Sequence[cq.Workplane] = [],
     colors: dict = {}
-):
+) -> Assembly:
     """
     Creates a tokamak fusion reactor from a radial and vertical build.
 

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -1,6 +1,7 @@
-from typing import Optional, Sequence, Tuple, Union
+from typing import Sequence, Tuple
 
 import cadquery as cq
+from .assembly import Assembly
 
 from ..utils import get_plasma_index, LayerType
 from ..workplanes.blanket_from_plasma import blanket_from_plasma
@@ -272,7 +273,7 @@ def tokamak(
         center_column=inner_radial_build[0],  # blanket_cutting_cylinder,
     )
 
-    my_assembly = cq.Assembly()
+    my_assembly = Assembly()
 
     for i, entry in enumerate(extra_cut_shapes):
         if isinstance(entry, cq.Workplane):

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -323,4 +323,9 @@ def tokamak(
 
     my_assembly.add(plasma, name="plasma", color=cq.Color(*colors.get("plasma", (0.5,0.5,0.5))))
 
+    my_assembly.elongation = elongation
+    my_assembly.triangularity = triangularity
+    my_assembly.major_radius = major_radius
+    my_assembly.minor_radius = minor_radius
+
     return my_assembly

--- a/tests/test_assemblies/test_assembly.py
+++ b/tests/test_assemblies/test_assembly.py
@@ -9,7 +9,6 @@ def test_remove_and_names():
     assembly.add(box1, name="box1", color=cq.Color(0.5, 0.5, 0.5))
     assembly.add(sphere1, name="sphere")
 
-
     assembly2 = assembly.remove('sphere')
     assembly3 = assembly.remove('box1')
     assembly4 = assembly.remove('bosdfsdf')

--- a/tests/test_assemblies/test_assembly.py
+++ b/tests/test_assemblies/test_assembly.py
@@ -1,0 +1,20 @@
+import cadquery as cq
+from paramak.assemblies.assembly import Assembly
+
+def test_remove_and_names():
+
+    sphere1 = cq.Workplane().moveTo(2, 2).sphere(1)
+    box1 = cq.Workplane().box(1, 1, 1)
+    assembly = Assembly()
+    assembly.add(box1, name="box1", color=cq.Color(0.5, 0.5, 0.5))
+    assembly.add(sphere1, name="sphere")
+
+
+    assembly2 = assembly.remove('sphere')
+    assembly3 = assembly.remove('box1')
+    assembly4 = assembly.remove('bosdfsdf')
+
+    assert assembly.names() == ['box1', 'sphere']
+    assert assembly2.names() == ['box1']
+    assert assembly3.names() == ['sphere']
+    assert assembly4.names() == ['box1', 'sphere']

--- a/tests/test_assemblies/test_spherical_tokamak.py
+++ b/tests/test_assemblies/test_spherical_tokamak.py
@@ -19,7 +19,7 @@ def test_transport_with_magnets(rotation_angle):
         [10, 15],
         [20, 50],
         [20, 50],
-        [(500, 300), (610, 100)],
+        [(500, 300), (590, 100)],
     ):
         poloidal_field_coils.append(
             paramak.poloidal_field_coil(
@@ -156,3 +156,5 @@ def test_attributes():
 
     assert my_reactor.elongation == 2
     assert my_reactor.triangularity == 0.55
+    assert my_reactor.major_radius == 275
+    assert my_reactor.minor_radius == 150

--- a/tests/test_assemblies/test_spherical_tokamak.py
+++ b/tests/test_assemblies/test_spherical_tokamak.py
@@ -134,3 +134,25 @@ def test_colors():
             "layer_5": (0.5, 0.5, 0.8),
         },
     )
+
+def test_attributes():
+    "passing in the colors dictionary should not raise an error"
+    my_reactor = paramak.spherical_tokamak_from_plasma(
+        radial_build=[
+            (paramak.LayerType.GAP, 10),
+            (paramak.LayerType.SOLID, 50),
+            (paramak.LayerType.SOLID, 15),
+            (paramak.LayerType.GAP, 50),
+            (paramak.LayerType.PLASMA, 300),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.SOLID, 15),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+        ],
+        elongation=2,
+        triangularity=0.55,
+        rotation_angle=180,
+    )
+
+    assert my_reactor.elongation == 2
+    assert my_reactor.triangularity == 0.55

--- a/tests/test_assemblies/test_spherical_tokamak.py
+++ b/tests/test_assemblies/test_spherical_tokamak.py
@@ -19,7 +19,7 @@ def test_transport_with_magnets(rotation_angle):
         [10, 15],
         [20, 50],
         [20, 50],
-        [(500, 300), (590, 100)],
+        [(500, 300), (610, 100)],
     ):
         poloidal_field_coils.append(
             paramak.poloidal_field_coil(


### PR DESCRIPTION
the paramak.Assembly adds ```remove``` and ```names``` for now which will help users know the number of material tags to use in the neutornics model.
It will also allow users to remove the plasma shape from the assembly and therefore neutronics simulation