### PR TITLE
Fixing the build of Princeton-D TF Coils

### DIFF
--- a/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
+++ b/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
@@ -189,7 +189,6 @@ def toroidal_field_coil_princeton_d(
     Returns:
         solid: The created toroidal field coil solid.
     """
-    print("r2", r2)
     points, inner_leg_connection_points, inner_points, outer_points = find_points(
         r1, r2, thickness, vertical_displacement
     )

--- a/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
+++ b/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
@@ -2,7 +2,7 @@ import typing
 import numpy as np
 from ..utils import create_wire_workplane_from_points, rotate_solid
 from scipy import integrate
-from scipy.optimize import minimize
+from scipy.optimize import minimize, brentq
 from typing import List, Tuple
 from ..workplanes.cutting_wedge import cutting_wedge
 
@@ -19,13 +19,13 @@ def _compute_inner_points(R1, R2):
         points
     """
 
-    def error(z_0, R0, R2):
+    def error(z_0):
         segment = get_segment(R0, R2, z_0)
-        return abs(segment[1][-1])
+        return segment[1][-1]
 
     def get_segment(a, b, z_0, num=5):
         a_R = np.linspace(a, b, num=num, endpoint=True)
-        asol = integrate.odeint(solvr, [z_0[0], 0], a_R)
+        asol = integrate.odeint(solvr, [z_0, 0], a_R)
         return a_R, asol[:, 0], asol[:, 1]
 
     def solvr(Y, R):
@@ -34,11 +34,14 @@ def _compute_inner_points(R1, R2):
     R0 = (R1 * R2) ** 0.5
     k = 0.5 * np.log(R2 / R1)
 
-    # computing of z_0
-    # z_0 is computed by ensuring outer segment end is zero
-    z_0 = 10  # initial guess for z_0
-    res = minimize(error, z_0, args=(R0, R2))
-    z_0 = res.x
+    def find_intersect():
+        z_lo, z_hi = -10.0, 10.0
+        while error(z_lo) * error(z_hi) > 0:
+            z_lo *= 2.0
+            z_hi *= 2.0
+        return brentq(error, z_lo, z_hi)
+
+    z_0 = find_intersect()
 
     # compute inner and outer segments
     segment1 = get_segment(R0, R1, z_0)
@@ -186,6 +189,7 @@ def toroidal_field_coil_princeton_d(
     Returns:
         solid: The created toroidal field coil solid.
     """
+    print("r2", r2)
     points, inner_leg_connection_points, inner_points, outer_points = find_points(
         r1, r2, thickness, vertical_displacement
     )

--- a/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
+++ b/src/paramak/workplanes/toroidal_field_coil_princeton_d.py
@@ -2,7 +2,7 @@ import typing
 import numpy as np
 from ..utils import create_wire_workplane_from_points, rotate_solid
 from scipy import integrate
-from scipy.optimize import minimize, brentq
+from scipy.optimize import brentq
 from typing import List, Tuple
 from ..workplanes.cutting_wedge import cutting_wedge
 


### PR DESCRIPTION
I was trying to build a simple parametric ST with Princeton-D TF coils. When using certain paramaterisations the build would hang and never finish. 

Here is the code I was using: 
```
import paramak

tf_style_2 = paramak.toroidal_field_coil_princeton_d(
    r1=5,
    r2=800,
    thickness=50,
    distance=40,
    azimuthal_placement_angles=[0],
    rotation_angle=90,
)

result2 = paramak.spherical_tokamak_from_plasma(
    radial_build=[
        (paramak.LayerType.GAP, 70),
        (paramak.LayerType.SOLID, 10),
        (paramak.LayerType.SOLID, 10),
        (paramak.LayerType.GAP, 50),
        (paramak.LayerType.PLASMA, 300),
        (paramak.LayerType.GAP, 60),
        (paramak.LayerType.SOLID, 10),
        (paramak.LayerType.SOLID, 60),
        (paramak.LayerType.SOLID, 10),
    ],
    elongation=2.5,
    rotation_angle=90,
    triangularity=0.55,
    extra_cut_shapes=[tf_style_2],
)

result2.save("spherical_tokamak_from_plasma_with_prin_tf_coils.step")
```

I swept r2: 100<=r2<=800.

I have a scan through the source and printed it out. It appeared to be getting stuck on the minimize() function for the error. Digging into this the error is calculating the distance between the guess and the actual value of z_0. To calculate z_0 we want the error to =0. I therefore decided to switch out the minmize function for a bracketed root-finder, where the problem can collapse quickly without being sensitive to the z_0 guess. It should be more robust and take fewer evaluations. This has solved the problem, and with a wide range of TF configurations I can get a build. 

There is now a warning showing for the solver: 
```
 lsoda--  warning..internal t (=r1) and h (=r2) are
       such that in the machine, t + h = t on the next step  
       (h = step size). solver will continue anyway
      in above,  r1 =  0.7999999135914D+03   r2 =  0.5342192331493D-13
```

I was going to set another PR focused on fixing this warning, but wanted to get eyes on this first now that the build completes consistently.