### PR TITLE
Fixing the princeton-D TF code examples in the docs

### DIFF
--- a/docs/examples_spherical_tokamak.rst
+++ b/docs/examples_spherical_tokamak.rst
@@ -417,7 +417,7 @@ Spherical tokamak with toroidal field coils
     tf_style_2 = paramak.toroidal_field_coil_princeton_d(
         r1=5,
         r2=610,
-        azimuthal_placement_angles = [120, 150, 180],
+        azimuthal_placement_angles = [0, 30, 60, 90, 120, 150, 180],
         rotation_angle = 180,
         thickness = 50,
         distance = 40

--- a/docs/examples_spherical_tokamak.rst
+++ b/docs/examples_spherical_tokamak.rst
@@ -438,7 +438,7 @@ Spherical tokamak with toroidal field coils
         elongation=2.5,
         rotation_angle=180,
         triangularity=0.55,
-        extra_cut_shapes=[tf]
+        extra_cut_shapes=[tf_style_2]
     )
 
     result2.save(f"spherical_tokamak_with_princeton_tf.step")


### PR DESCRIPTION
There were two minor edits in the doc example code: 
- Placement of TFs in the code didn't align with the visualisation above. 
- Naming of the TF object in the extra_cut_shapes was incorrect (TF->TF_style_2)