### PR TITLE
Add cuttable solid layer support

### DIFF
--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -23,7 +23,11 @@ class Assembly(cq.Assembly):
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')
-        self._copy_metadata(new_assembly)
+
+        new_assembly.elongation = self.elongation
+        new_assembly.triangularity = self.triangularity
+        new_assembly.major_radius = self.major_radius
+        new_assembly.minor_radius = self.minor_radius
         return new_assembly
 
     def names(self):

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -13,13 +13,6 @@ class Assembly(cq.Assembly):
     major_radius = None
     minor_radius = None
 
-    def _copy_metadata(self, target):
-        """Copies tokamak geometry metadata to another Assembly instance."""
-        target.elongation = self.elongation
-        target.triangularity = self.triangularity
-        target.major_radius = self.major_radius
-        target.minor_radius = self.minor_radius
-
     def remove(self, name: str):
         new_assembly = Assembly()
         part_found = False
@@ -38,42 +31,3 @@ class Assembly(cq.Assembly):
         for part in self:
             names.append(part[1].split('/')[-1])
         return names
-
-    def split_solids(self):
-        """
-        Explodes any part containing multiple solids into individually named parts.
-
-        Naming convention:
-          - Single-solid parts: name unchanged
-          - Multi-solid parts:  <original_name>_1, <original_name>_2, ... <original_name>_N
-
-        Example:
-          'add_extra_cut_shape_1' with 16 solids becomes:
-          'add_extra_cut_shape_1_1' through 'add_extra_cut_shape_1_16'
-        """
-        new_assembly = Assembly()
-
-        for part in self:
-            obj, full_path, loc, color = part
-            leaf_name = full_path.split('/')[-1]
-
-            if isinstance(obj, cq.Workplane):
-                solids = obj.solids().vals()
-                plane = obj.plane
-            elif isinstance(obj, cq.Shape):
-                solids = obj.Solids()
-                plane = None
-            else:
-                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
-                continue
-
-            if len(solids) <= 1:
-                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
-            else:
-                for idx, solid in enumerate(solids, start=1):
-                    split_name = f"{leaf_name}_{idx}"
-                    new_obj = cq.Workplane(plane).add(solid) if plane is not None else solid
-                    new_assembly.add(new_obj, name=split_name, color=color, loc=loc)
-
-        self._copy_metadata(new_assembly)
-        return new_assembly

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -35,3 +35,32 @@ class Assembly(cq.Assembly):
         for part in self:
             names.append(part[1].split('/')[-1])
         return names
+
+    def fuse_solids(self):
+        """Combines multi-solid parts into single solids for export."""
+        new_assembly = Assembly()
+        for part in self:
+            obj, name, loc, color = part
+            if isinstance(obj, cq.Workplane):
+                solids = obj.solids().vals()
+                if len(solids) > 1:
+                    fused_shape = solids[0]
+                    for solid in solids[1:]:
+                        fused_shape = fused_shape.fuse(solid)
+                    if hasattr(fused_shape, "removeSplitter"):
+                        fused_shape = fused_shape.removeSplitter()
+                    obj = cq.Workplane(obj.plane).add(fused_shape).clean()
+                    if len(obj.solids().vals()) > 1:
+                        compound = cq.Compound.makeCompound(solids)
+                        obj = cq.Workplane(obj.plane).add(compound).combine()
+                    if len(obj.solids().vals()) > 1:
+                        warnings.warn(f"Part {name} still has {len(obj.solids().vals())} solids after fusing")
+                else:
+                    obj = obj.combine()
+            new_assembly.add(obj, name=name, color=color, loc=loc)
+
+        new_assembly.elongation = self.elongation
+        new_assembly.triangularity = self.triangularity
+        new_assembly.major_radius = self.major_radius
+        new_assembly.minor_radius = self.minor_radius
+        return new_assembly

--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -8,10 +8,17 @@ import cadquery as cq
 class Assembly(cq.Assembly):
     """Nested assembly of Workplane and Shape objects defining their relative positions."""
 
-    elongation=None
-    triangularity=None
-    major_radius=None
-    minor_radius=None
+    elongation = None
+    triangularity = None
+    major_radius = None
+    minor_radius = None
+
+    def _copy_metadata(self, target):
+        """Copies tokamak geometry metadata to another Assembly instance."""
+        target.elongation = self.elongation
+        target.triangularity = self.triangularity
+        target.major_radius = self.major_radius
+        target.minor_radius = self.minor_radius
 
     def remove(self, name: str):
         new_assembly = Assembly()
@@ -23,11 +30,7 @@ class Assembly(cq.Assembly):
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')
-
-        new_assembly.elongation = self.elongation
-        new_assembly.triangularity = self.triangularity
-        new_assembly.major_radius = self.major_radius
-        new_assembly.minor_radius = self.minor_radius
+        self._copy_metadata(new_assembly)
         return new_assembly
 
     def names(self):
@@ -36,31 +39,41 @@ class Assembly(cq.Assembly):
             names.append(part[1].split('/')[-1])
         return names
 
-    def fuse_solids(self):
-        """Combines multi-solid parts into single solids for export."""
+    def split_solids(self):
+        """
+        Explodes any part containing multiple solids into individually named parts.
+
+        Naming convention:
+          - Single-solid parts: name unchanged
+          - Multi-solid parts:  <original_name>_1, <original_name>_2, ... <original_name>_N
+
+        Example:
+          'add_extra_cut_shape_1' with 16 solids becomes:
+          'add_extra_cut_shape_1_1' through 'add_extra_cut_shape_1_16'
+        """
         new_assembly = Assembly()
+
         for part in self:
-            obj, name, loc, color = part
+            obj, full_path, loc, color = part
+            leaf_name = full_path.split('/')[-1]
+
             if isinstance(obj, cq.Workplane):
                 solids = obj.solids().vals()
-                if len(solids) > 1:
-                    fused_shape = solids[0]
-                    for solid in solids[1:]:
-                        fused_shape = fused_shape.fuse(solid)
-                    if hasattr(fused_shape, "removeSplitter"):
-                        fused_shape = fused_shape.removeSplitter()
-                    obj = cq.Workplane(obj.plane).add(fused_shape).clean()
-                    if len(obj.solids().vals()) > 1:
-                        compound = cq.Compound.makeCompound(solids)
-                        obj = cq.Workplane(obj.plane).add(compound).combine()
-                    if len(obj.solids().vals()) > 1:
-                        warnings.warn(f"Part {name} still has {len(obj.solids().vals())} solids after fusing")
-                else:
-                    obj = obj.combine()
-            new_assembly.add(obj, name=name, color=color, loc=loc)
+                plane = obj.plane
+            elif isinstance(obj, cq.Shape):
+                solids = obj.Solids()
+                plane = None
+            else:
+                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
+                continue
 
-        new_assembly.elongation = self.elongation
-        new_assembly.triangularity = self.triangularity
-        new_assembly.major_radius = self.major_radius
-        new_assembly.minor_radius = self.minor_radius
+            if len(solids) <= 1:
+                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
+            else:
+                for idx, solid in enumerate(solids, start=1):
+                    split_name = f"{leaf_name}_{idx}"
+                    new_obj = cq.Workplane(plane).add(solid) if plane is not None else solid
+                    new_assembly.add(new_obj, name=split_name, color=color, loc=loc)
+
+        self._copy_metadata(new_assembly)
         return new_assembly

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple
 import cadquery as cq
 from .assembly import Assembly
 
-from ..utils import get_plasma_index, LayerType
+from ..utils import get_plasma_index, get_layer_type, is_layer_cut, LayerType
 from ..workplanes.blanket_from_plasma import blanket_from_plasma
 from ..workplanes.center_column_shield_cylinder import center_column_shield_cylinder
 from ..workplanes.plasma_simplified import plasma_simplified
@@ -16,9 +16,9 @@ def count_cylinder_layers(radial_build):
     found_plasma = False
 
     for item in radial_build:
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             found_plasma = True
-        elif item[0] == LayerType.SOLID:
+        elif get_layer_type(item[0]) == LayerType.SOLID:
             if not found_plasma:
                 before_plasma += 1
             else:
@@ -35,10 +35,10 @@ def create_center_column_shield_cylinders(radial_build, rotation_angle, center_c
     number_of_cylinder_layers = count_cylinder_layers(radial_build)
 
     for _, item in enumerate(radial_build):
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             break
 
-        if item[0] == LayerType.GAP:
+        if get_layer_type(item[0]) == LayerType.GAP:
             total_sum += item[1]
             continue
 
@@ -63,7 +63,7 @@ def create_center_column_shield_cylinders(radial_build, rotation_angle, center_c
 def distance_to_plasma(radial_build, index):
     distance = 0
     for item in radial_build[index + 1 :]:
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             break
         distance += item[1]
     return distance
@@ -84,14 +84,17 @@ def create_layers_from_plasma(
     cumulative_thickness_lvb = 0
     for index_delta in range(indexes_from_plasma_to_end):
 
-        if radial_build[plasma_index_rb + index_delta][0] == LayerType.PLASMA:
+        outer_layer_entry = radial_build[plasma_index_rb + index_delta][0]
+        inner_layer_entry = radial_build[plasma_index_rb - index_delta][0]
+        radial_layer_type = get_layer_type(outer_layer_entry)
+        if radial_layer_type == LayerType.PLASMA:
             continue
         outer_layer_thickness = radial_build[plasma_index_rb + index_delta][1]
         inner_layer_thickness = radial_build[plasma_index_rb - index_delta][1]
         upper_layer_thickness = vertical_build[plasma_index_vb - index_delta][1]
         lower_layer_thickness = vertical_build[plasma_index_vb + index_delta][1]
 
-        if radial_build[plasma_index_rb + index_delta][0] == LayerType.GAP:
+        if radial_layer_type == LayerType.GAP:
             cumulative_thickness_orb += outer_layer_thickness
             cumulative_thickness_irb += inner_layer_thickness
             cumulative_thickness_uvb += upper_layer_thickness
@@ -99,7 +102,8 @@ def create_layers_from_plasma(
             continue
 
         # build outer layer
-        if radial_build[plasma_index_rb + index_delta][0] == LayerType.SOLID:
+        if radial_layer_type == LayerType.SOLID:
+            cut_layer = is_layer_cut(outer_layer_entry) or is_layer_cut(inner_layer_entry)
             outer_layer = blanket_from_plasma(
                 minor_radius=minor_radius,
                 major_radius=major_radius,
@@ -136,8 +140,11 @@ def create_layers_from_plasma(
                 name=f"layer_{index_delta}",
                 allow_overlapping_shape=True,
             )
-            layer = outer_layer.union(inner_layer)
-            layers.append(layer)
+            if cut_layer:
+                layers.append({"cut": True, "shapes": [outer_layer, inner_layer]})
+            else:
+                layer = outer_layer.union(inner_layer)
+                layers.append({"cut": False, "shapes": [layer]})
             # layers.append(inner_layer)
         cumulative_thickness_orb += outer_layer_thickness
         cumulative_thickness_irb += inner_layer_thickness
@@ -273,6 +280,19 @@ def tokamak(
         center_column=inner_radial_build[0],  # blanket_cutting_cylinder,
     )
 
+    layer_entries = []
+    for i, entry in enumerate(inner_radial_build):
+        layer_entries.append((f"layer_{i+1}", entry))
+
+    next_layer_index = len(inner_radial_build) + 1
+    for layer in blanket_layers:
+        if layer["cut"]:
+            layer_entries.append((f"layer_{next_layer_index}.1", layer["shapes"][0]))
+            layer_entries.append((f"layer_{next_layer_index}.2", layer["shapes"][1]))
+        else:
+            layer_entries.append((f"layer_{next_layer_index}", layer["shapes"][0]))
+        next_layer_index += 1
+
     my_assembly = Assembly()
 
     for i, entry in enumerate(extra_cut_shapes):
@@ -286,12 +306,12 @@ def tokamak(
     intersect_shapes_to_cut = []
     if len(extra_intersect_shapes) > 0:
         all_shapes = []
-        for shape in inner_radial_build + blanket_layers:
+        for _, shape in layer_entries:
             all_shapes.append(shape)
 
         # makes a union of the the radial build to use as a base for the intersect shapes
-        reactor_compound = inner_radial_build[0]
-        for i, entry in enumerate(inner_radial_build[1:] + blanket_layers):
+        reactor_compound = layer_entries[0][1]
+        for _, entry in layer_entries[1:]:
             reactor_compound = reactor_compound.union(entry)
 
         # adds the extra intersect shapes to the assembly
@@ -303,12 +323,11 @@ def tokamak(
 
     # builds just the core if there are no extra parts
     if len(extra_cut_shapes) == 0 and len(intersect_shapes_to_cut) == 0:
-        for i, entry in enumerate(inner_radial_build+blanket_layers):
-            name=f"layer_{i+1}"
+        for name, entry in layer_entries:
             my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
     else:
         shapes_and_components = []
-        for i, entry in enumerate(inner_radial_build + blanket_layers):
+        for _, entry in layer_entries:
             for cutter in extra_cut_shapes + extra_intersect_shapes:
                 entry = entry.cut(cutter)
                 # TODO use something like this to return a list of material tags for the solids in order, as some solids get split into multiple
@@ -316,8 +335,7 @@ def tokamak(
                 #     print(i, subentry)
             shapes_and_components.append(entry)
 
-        for i, entry in enumerate(shapes_and_components):
-            name=f"layer_{i+1}"
+        for (name, _), entry in zip(layer_entries, shapes_and_components):
             # TODO track the names of shapes, even when extra shapes are made due to splitting
             my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -87,6 +87,7 @@ def create_layers_from_plasma(
         outer_layer_entry = radial_build[plasma_index_rb + index_delta][0]
         inner_layer_entry = radial_build[plasma_index_rb - index_delta][0]
         radial_layer_type = get_layer_type(outer_layer_entry)
+        inner_layer_type = get_layer_type(inner_layer_entry)
         if radial_layer_type == LayerType.PLASMA:
             continue
         outer_layer_thickness = radial_build[plasma_index_rb + index_delta][1]
@@ -103,7 +104,10 @@ def create_layers_from_plasma(
 
         # build outer layer
         if radial_layer_type == LayerType.SOLID:
-            cut_layer = is_layer_cut(outer_layer_entry) or is_layer_cut(inner_layer_entry)
+            cut_layer = (
+                inner_layer_type == LayerType.SOLID
+                and (is_layer_cut(outer_layer_entry) or is_layer_cut(inner_layer_entry))
+            )
             outer_layer = blanket_from_plasma(
                 minor_radius=minor_radius,
                 major_radius=major_radius,
@@ -268,6 +272,11 @@ def tokamak(
     inner_radial_build = create_center_column_shield_cylinders(
         radial_build, rotation_angle, blanket_rear_wall_end_height
     )
+
+    if len(inner_radial_build) == 0:
+        raise ValueError(
+            "No inner SOLID layers found before the plasma; add more inner SOLID layers or remove outer ones."
+        )
 
     blanket_layers = create_layers_from_plasma(
         radial_build=radial_build,

--- a/src/paramak/utils.py
+++ b/src/paramak/utils.py
@@ -1,4 +1,5 @@
 import typing
+from dataclasses import dataclass
 from enum import Enum
 
 from cadquery import Workplane
@@ -8,6 +9,25 @@ class LayerType(Enum):
     GAP = "gap"
     SOLID = "solid"
     PLASMA = "plasma"
+
+    def __call__(self, cut: bool = False):
+        return LayerSpec(layer_type=self, cut=cut)
+
+
+@dataclass(frozen=True)
+class LayerSpec:
+    layer_type: LayerType
+    cut: bool = False
+
+
+def get_layer_type(layer_entry):
+    if isinstance(layer_entry, LayerSpec):
+        return layer_entry.layer_type
+    return layer_entry
+
+
+def is_layer_cut(layer_entry) -> bool:
+    return isinstance(layer_entry, LayerSpec) and layer_entry.cut
 
 
 def instructions_from_points(points):
@@ -108,9 +128,13 @@ def rotate_solid(angles: typing.Sequence[float], solid: Workplane) -> Workplane:
 def sum_up_to_gap_before_plasma(radial_build):
     total_sum = 0
     for i, item in enumerate(radial_build):
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             return total_sum
-        if item[0] == LayerType.GAP and i + 1 < len(radial_build) and radial_build[i + 1][0] == LayerType.PLASMA:
+        if (
+            get_layer_type(item[0]) == LayerType.GAP
+            and i + 1 < len(radial_build)
+            and get_layer_type(radial_build[i + 1][0]) == LayerType.PLASMA
+        ):
             return total_sum
         total_sum += item[1]
     return total_sum
@@ -119,7 +143,7 @@ def sum_up_to_gap_before_plasma(radial_build):
 def sum_up_to_plasma(radial_build):
     total_sum = 0
     for item in radial_build:
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             break
         total_sum += item[1]
     return total_sum
@@ -131,7 +155,7 @@ def sum_after_plasma(radial_build):
     for item in radial_build:
         if plasma_found:
             total_sum += item[1]
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             plasma_found = True
     return total_sum
 
@@ -147,7 +171,7 @@ def sum_before_after_plasma(vertical_build):
     plasma_found = False
 
     for item in vertical_build:
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             plasma_value = item[1] / 2
             plasma_found = True
             continue
@@ -188,7 +212,7 @@ def is_plasma_radial_build(radial_build):
     for entry in radial_build:
         # if entry == LayerType.PLASMA:
         #     return True
-        if entry[0] == LayerType.PLASMA:
+        if get_layer_type(entry[0]) == LayerType.PLASMA:
             return True
     return False
 
@@ -231,15 +255,19 @@ def validate_plasma_radial_build(radial_build):
     plasma_count = 0
     plasma_index = -1
     for index, item in enumerate(radial_build):
-        if not isinstance(item[0], LayerType):
-            raise ValidationError(f"First entry in each radial build Tuple should be a paramak.LayerType")
+        layer_entry = item[0]
+        layer_type = get_layer_type(layer_entry)
+        if not isinstance(layer_type, LayerType):
+            raise ValidationError("First entry in each radial build Tuple should be a paramak.LayerType")
+        if is_layer_cut(layer_entry) and layer_type != LayerType.SOLID:
+            raise ValidationError("Only LayerType.SOLID entries can set cut=True")
         if not isinstance(item[1], (int, float)):
             raise ValidationError(f"Second entry in each radial build Tuple should be a Float")
-        if item[0] not in valid_strings:
-            raise ValidationError(f"Invalid entry '{item[0]}' at index {index}")
+        if layer_type not in valid_strings:
+            raise ValidationError(f"Invalid entry '{layer_type}' at index {index}")
         if item[1] <= 0:
             raise ValidationError(f"Non-positive value '{item[1]}' at index {index}")
-        if item[0] == LayerType.PLASMA:
+        if layer_type == LayerType.PLASMA:
             plasma_count += 1
             plasma_index = index
             if plasma_count > 1:
@@ -248,7 +276,10 @@ def validate_plasma_radial_build(radial_build):
         raise ValidationError("LayerType.PLASMA entry not found or found multiple times")
     if plasma_index == 0 or plasma_index == len(radial_build) - 1:
         raise ValidationError("LayerType.PLASMA entry must have at least one entry before and after it")
-    if radial_build[plasma_index - 1][0] != LayerType.GAP or radial_build[plasma_index + 1][0] != LayerType.GAP:
+    if (
+        get_layer_type(radial_build[plasma_index - 1][0]) != LayerType.GAP
+        or get_layer_type(radial_build[plasma_index + 1][0]) != LayerType.GAP
+    ):
         raise ValidationError("LayerType.PLASMA entry must be preceded and followed by a LayerType.GAP")
 
 
@@ -263,22 +294,22 @@ def is_lower_or_upper_divertor(radial_build):
 
 def get_plasma_value(radial_build):
     for item in radial_build:
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             return item[1]
     raise ValueError("LayerType.PLASMA entry not found")
 
 
 def get_plasma_index(radial_build):
     for i, item in enumerate(radial_build):
-        if item[0] == LayerType.PLASMA:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
             return i
     raise ValueError("LayerType.PLASMA entry not found")
 
 
 def get_gap_after_plasma(radial_build):
     for index, item in enumerate(radial_build):
-        if item[0] == LayerType.PLASMA:
-            if index + 1 < len(radial_build) and radial_build[index + 1][0] == LayerType.GAP:
+        if get_layer_type(item[0]) == LayerType.PLASMA:
+            if index + 1 < len(radial_build) and get_layer_type(radial_build[index + 1][0]) == LayerType.GAP:
                 return radial_build[index + 1][1]
             else:
                 raise ValueError("LayerType.PLASMA entry is not followed by a 'gap'")
@@ -293,9 +324,9 @@ def sum_after_gap_following_plasma(radial_build):
     for item in radial_build:
         if found_gap_after_plasma:
             total_sum += item[1]
-        elif found_plasma and item[0] == LayerType.GAP:
+        elif found_plasma and get_layer_type(item[0]) == LayerType.GAP:
             found_gap_after_plasma = True
-        elif item[0] == LayerType.PLASMA:
+        elif get_layer_type(item[0]) == LayerType.PLASMA:
             found_plasma = True
 
     if not found_plasma:

--- a/tests/test_assemblies/test_assembly.py
+++ b/tests/test_assemblies/test_assembly.py
@@ -17,22 +17,3 @@ def test_remove_and_names():
     assert assembly2.names() == ['box1']
     assert assembly3.names() == ['sphere']
     assert assembly4.names() == ['box1', 'sphere']
-
-
-def test_split_solids():
-    # A compound with 2 solids (two spheres at different positions)
-    multi_solid = cq.Compound.makeCompound([
-        cq.Workplane().moveTo(0, 0).sphere(1).val(),
-        cq.Workplane().moveTo(10, 0).sphere(1).val(),
-    ])
-    single_solid = cq.Workplane().box(1, 1, 1)
-
-    assembly = Assembly()
-    assembly.add(multi_solid, name="multi")
-    assembly.add(single_solid, name="single")
-
-    split = assembly.split_solids()
-
-    # single-solid part keeps its name unchanged
-    # multi-solid part becomes multi_1 and multi_2
-    assert split.names() == ['multi_1', 'multi_2', 'single']

--- a/tests/test_assemblies/test_assembly.py
+++ b/tests/test_assemblies/test_assembly.py
@@ -17,3 +17,22 @@ def test_remove_and_names():
     assert assembly2.names() == ['box1']
     assert assembly3.names() == ['sphere']
     assert assembly4.names() == ['box1', 'sphere']
+
+
+def test_split_solids():
+    # A compound with 2 solids (two spheres at different positions)
+    multi_solid = cq.Compound.makeCompound([
+        cq.Workplane().moveTo(0, 0).sphere(1).val(),
+        cq.Workplane().moveTo(10, 0).sphere(1).val(),
+    ])
+    single_solid = cq.Workplane().box(1, 1, 1)
+
+    assembly = Assembly()
+    assembly.add(multi_solid, name="multi")
+    assembly.add(single_solid, name="single")
+
+    split = assembly.split_solids()
+
+    # single-solid part keeps its name unchanged
+    # multi-solid part becomes multi_1 and multi_2
+    assert split.names() == ['multi_1', 'multi_2', 'single']

--- a/tests/test_assemblies/test_tokamak.py
+++ b/tests/test_assemblies/test_tokamak.py
@@ -1,4 +1,5 @@
 import paramak
+import pytest
 
 
 def test_colors():
@@ -31,3 +32,26 @@ def test_colors():
             "layer_5": (0.5, 0.5, 0.8),
         }
     )
+
+
+def test_tokamak_no_inner_layers_error():
+    radial_build = [
+        (paramak.LayerType.GAP, 10),
+        (paramak.LayerType.SOLID, 20),
+        (paramak.LayerType.GAP, 10),
+        (paramak.LayerType.PLASMA, 100),
+        (paramak.LayerType.GAP, 10),
+        (paramak.LayerType.SOLID, 20),
+    ]
+    vertical_build = [
+        (paramak.LayerType.GAP, 20),
+        (paramak.LayerType.PLASMA, 200),
+        (paramak.LayerType.GAP, 20),
+    ]
+
+    with pytest.raises(ValueError, match="No inner SOLID layers found before the plasma"):
+        paramak.tokamak(
+            radial_build=radial_build,
+            vertical_build=vertical_build,
+            rotation_angle=180,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -511,26 +511,72 @@ def test_invalid_string():
 
 def test_cut_on_solid_valid():
     radial_build = [
-        (LayerType.GAP, 10),
-        (LayerType.SOLID(cut=True), 50),
-        (LayerType.GAP, 5),
-        (LayerType.PLASMA, 50),
-        (LayerType.GAP, 60),
-        (LayerType.SOLID, 2),
-        (LayerType.GAP, 10),
+        (
+            LayerType.GAP,
+            10,
+        ),
+        (
+            LayerType.SOLID,
+            50,
+        ),
+        (
+            LayerType.GAP,
+            5,
+        ),
+        (
+            LayerType.SOLID(cut=True),
+            50,
+        ),
+        (
+            LayerType.GAP,
+            5,
+        ),
+        (
+            LayerType.PLASMA,
+            50,
+        ),
+        (
+            LayerType.GAP,
+            60,
+        ),
+        (
+            LayerType.SOLID,
+            2,
+        ),
     ]
     validate_plasma_radial_build(radial_build)
 
 
 def test_cut_on_gap_invalid():
     radial_build = [
-        (LayerType.GAP(cut=True), 10),
-        (LayerType.SOLID, 50),
-        (LayerType.GAP, 5),
-        (LayerType.PLASMA, 50),
-        (LayerType.GAP, 60),
-        (LayerType.SOLID, 2),
-        (LayerType.GAP, 10),
+        (
+            LayerType.GAP(cut=True),
+            10,
+        ),
+        (
+            LayerType.SOLID,
+            50,
+        ),
+        (
+            LayerType.GAP,
+            5,
+        ),
+        (
+            LayerType.PLASMA,
+            50,
+        ),
+        (
+            LayerType.GAP,
+            60,
+        ),
+        (
+            LayerType.SOLID,
+            2,
+        ),
+        (
+            LayerType.GAP,
+            10,
+        ),
     ]
     with pytest.raises(ValidationError, match="Only LayerType.SOLID entries can set cut=True"):
         validate_plasma_radial_build(radial_build)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -509,6 +509,33 @@ def test_invalid_string():
         validate_plasma_radial_build(radial_build)
 
 
+def test_cut_on_solid_valid():
+    radial_build = [
+        (LayerType.GAP, 10),
+        (LayerType.SOLID(cut=True), 50),
+        (LayerType.GAP, 5),
+        (LayerType.PLASMA, 50),
+        (LayerType.GAP, 60),
+        (LayerType.SOLID, 2),
+        (LayerType.GAP, 10),
+    ]
+    validate_plasma_radial_build(radial_build)
+
+
+def test_cut_on_gap_invalid():
+    radial_build = [
+        (LayerType.GAP(cut=True), 10),
+        (LayerType.SOLID, 50),
+        (LayerType.GAP, 5),
+        (LayerType.PLASMA, 50),
+        (LayerType.GAP, 60),
+        (LayerType.SOLID, 2),
+        (LayerType.GAP, 10),
+    ]
+    with pytest.raises(ValidationError, match="Only LayerType.SOLID entries can set cut=True"):
+        validate_plasma_radial_build(radial_build)
+
+
 def test_plasma_first_entry():
     radial_build = [
         (


### PR DESCRIPTION
# Summary
This PR introduces several improvements to the plasma-layer handling:

- Adds `LayerType.SOLID(cut=True)` support to split layers across the plasma boundary with stable naming (layer_N.1, layer_N.2)
- Adds validation for missing inner SOLID layers before the plasma.
- Adds comprehensive tests for cut validation behavior.
- Ensure **cut** only happens when layers exist on both sides of the plasma.

# Motivation
Most of the time the Inner Board and Outer Board layers of a **tokamak** have different material compositions. Till now we need to create a continuous layer which can contain a single material composition. So, this PR improves SOLID layer handling by enabling deterministic splitting of layers while validating invalid configurations early.

### 1. Add `LayerType.SOLID(cut=True)` support
```
model = paramak.tokamak_from_plasma(
    radial_build = [
        (LayerType.GAP, 10),
        (LayerType.SOLID, 20),     # layer_1
        (LayerType.SOLID, 20),     # layer_2
        (LayerType.GAP, 5),
        (LayerType.SOLID(cut=True), 20),     # layer_4.1
        (LayerType.GAP, 5),
        (LayerType.SOLID, 10),     # layer_3
        (LayerType.GAP, 10),
        (LayerType.PLASMA, 100),     # plasma
        (LayerType.GAP, 10),
        (LayerType.SOLID, 20),     # layer_3
        (LayerType.GAP, 5),
        (LayerType.SOLID, 40),     # layer_4.2
    ],
    triangularity=0.55,
    rotation_angle=180,
)

print(model.names())
```
output:
`['layer_1', 'layer_2', 'layer_3', 'layer_4.1', 'layer_4.2', 'plasma']`

**FreeCAD**
<img width="1920" height="1038" alt="Screenshot From 2026-05-26 22-43-06" src="https://github.com/user-attachments/assets/0cd97e86-042b-43ed-afe6-75b3eed75752" />


**New behavior**
SOLID layers can now be split across the plasma boundary.

Example naming:

```
layer_4.1
layer_4.2
```
**Validation behavior**
Splitting only occurs when geometry exists on both sides of the plasma.
`LayerType.SOLID(cut=True) `can be called **once or twice(both side of plasma)** but result will be same.
