### PR TITLE
Add split_solids() support and stable naming

### DIFF
--- a/src/paramak/assemblies/assembly.py
+++ b/src/paramak/assemblies/assembly.py
@@ -8,10 +8,17 @@ import cadquery as cq
 class Assembly(cq.Assembly):
     """Nested assembly of Workplane and Shape objects defining their relative positions."""
 
-    elongation=None
-    triangularity=None
-    major_radius=None
-    minor_radius=None
+    elongation = None
+    triangularity = None
+    major_radius = None
+    minor_radius = None
+
+    def _copy_metadata(self, target):
+        """Copies tokamak geometry metadata to another Assembly instance."""
+        target.elongation = self.elongation
+        target.triangularity = self.triangularity
+        target.major_radius = self.major_radius
+        target.minor_radius = self.minor_radius
 
     def remove(self, name: str):
         new_assembly = Assembly()
@@ -23,11 +30,7 @@ class Assembly(cq.Assembly):
                 new_assembly.add(part[0], name=part[1], color=part[3], loc=part[2])
         if not part_found:
             warnings.warn(f'Part with name {name} not found')
-
-        new_assembly.elongation = self.elongation
-        new_assembly.triangularity = self.triangularity
-        new_assembly.major_radius = self.major_radius
-        new_assembly.minor_radius = self.minor_radius
+        self._copy_metadata(new_assembly)
         return new_assembly
 
     def names(self):
@@ -35,3 +38,42 @@ class Assembly(cq.Assembly):
         for part in self:
             names.append(part[1].split('/')[-1])
         return names
+
+    def split_solids(self):
+        """
+        Explodes any part containing multiple solids into individually named parts.
+
+        Naming convention:
+          - Single-solid parts: name unchanged
+          - Multi-solid parts:  <original_name>_1, <original_name>_2, ... <original_name>_N
+
+        Example:
+          'add_extra_cut_shape_1' with 16 solids becomes:
+          'add_extra_cut_shape_1_1' through 'add_extra_cut_shape_1_16'
+        """
+        new_assembly = Assembly()
+
+        for part in self:
+            obj, full_path, loc, color = part
+            leaf_name = full_path.split('/')[-1]
+
+            if isinstance(obj, cq.Workplane):
+                solids = obj.solids().vals()
+                plane = obj.plane
+            elif isinstance(obj, cq.Shape):
+                solids = obj.Solids()
+                plane = None
+            else:
+                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
+                continue
+
+            if len(solids) <= 1:
+                new_assembly.add(obj, name=leaf_name, color=color, loc=loc)
+            else:
+                for idx, solid in enumerate(solids, start=1):
+                    split_name = f"{leaf_name}_{idx}"
+                    new_obj = cq.Workplane(plane).add(solid) if plane is not None else solid
+                    new_assembly.add(new_obj, name=split_name, color=color, loc=loc)
+
+        self._copy_metadata(new_assembly)
+        return new_assembly

--- a/src/paramak/assemblies/spherical_tokamak.py
+++ b/src/paramak/assemblies/spherical_tokamak.py
@@ -239,7 +239,12 @@ def spherical_tokamak(
     for i, entry in enumerate(extra_cut_shapes):
 
         if isinstance(entry, cq.Workplane):
-            name = f"add_extra_cut_shape_{i+1}"
+            # Use the object's name attribute if it exists, otherwise fallback
+            base_name = getattr(entry, 'name', None)
+            if base_name:
+                name = f"{base_name}_{i+1}"
+            else:
+                name = f"add_extra_cut_shape_{i+1}"
             my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
         else:
             raise ValueError(f"extra_cut_shapes should only contain cadquery Workplanes, not {type(entry)}")
@@ -260,7 +265,12 @@ def spherical_tokamak(
         for i, entry in enumerate(extra_intersect_shapes):
             reactor_entry_intersection = entry.intersect(reactor_compound)
             intersect_shapes_to_cut.append(reactor_entry_intersection)
-            name = f"extra_intersect_shapes_{i+1}"
+            # Use the object's name attribute if it exists, otherwise fallback
+            base_name = getattr(entry, 'name', None)
+            if base_name:
+                name = f"{base_name}_{i+1}"
+            else:
+                name=f"extra_intersect_shapes_{i+1}"
             my_assembly.add(reactor_entry_intersection, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
     # builds just the core if there are no extra parts

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -277,7 +277,12 @@ def tokamak(
 
     for i, entry in enumerate(extra_cut_shapes):
         if isinstance(entry, cq.Workplane):
-            name = f"add_extra_cut_shape_{i+1}"
+            # Use the object's name attribute if it exists, otherwise fallback
+            base_name = getattr(entry, 'name', None)
+            if base_name:
+                name = f"{base_name}_{i+1}"
+            else:
+                name = f"add_extra_cut_shape_{i+1}"
             my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
         else:
             raise ValueError(f"extra_cut_shapes should only contain cadquery Workplanes, not {type(entry)}")
@@ -298,7 +303,12 @@ def tokamak(
         for i, entry in enumerate(extra_intersect_shapes):
             reactor_entry_intersection = entry.intersect(reactor_compound)
             intersect_shapes_to_cut.append(reactor_entry_intersection)
-            name=f"extra_intersect_shapes_{i+1}"
+            # Use the object's name attribute if it exists, otherwise fallback
+            base_name = getattr(entry, 'name', None)
+            if base_name:
+                name = f"{base_name}_{i+1}"
+            else:
+                name=f"extra_intersect_shapes_{i+1}"
             my_assembly.add(reactor_entry_intersection, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
     # builds just the core if there are no extra parts

--- a/tests/test_assemblies/test_assembly.py
+++ b/tests/test_assemblies/test_assembly.py
@@ -17,3 +17,21 @@ def test_remove_and_names():
     assert assembly2.names() == ['box1']
     assert assembly3.names() == ['sphere']
     assert assembly4.names() == ['box1', 'sphere']
+
+def test_split_solids():
+    # A compound with 2 solids (two spheres at different positions)
+    multi_solid = cq.Compound.makeCompound([
+        cq.Workplane().moveTo(0, 0).sphere(1).val(),
+        cq.Workplane().moveTo(10, 0).sphere(1).val(),
+    ])
+    single_solid = cq.Workplane().box(1, 1, 1)
+
+    assembly = Assembly()
+    assembly.add(multi_solid, name="multi")
+    assembly.add(single_solid, name="single")
+
+    split = assembly.split_solids()
+
+    # single-solid part keeps its name unchanged
+    # multi-solid part becomes multi_1 and multi_2
+    assert split.names() == ['multi_1', 'multi_2', 'single']


### PR DESCRIPTION
# Summary
This PR introduces improvements to the custom `Assembly` workflow
- Adds `Assembly.split_solids()` to explode multi-solid compound parts into stable, individually named entries
- Adds tests for solid splitting

# Motivation
Compound CAD objects containing multiple disconnected solids are difficult to process downstream because they remain **grouped under a single entry**. Stable exploded naming is required for deterministic workflows, meshing, DAGMC export, and material assignment.

# Changes
### 1. Add stable naming
Before the extra_cut_shapes part was using `name = f"add_extra_cut_shape_{i+1}"`. But now it uses specific(default) cut names from the cut methods or we can assign name to the cut methods by setting `name="shape name"` inside the cut method as they have a `name` parameter by definition. And for multi solid parts it will add name as `<original name>_i ; (i = 1, 2, ...)` for each solid.

For the extra_intersect_shapes, we need to assign a name to them, like for divertor we may write:
```
divertor_lower = cq.Workplane("XZ", origin=(0, 0, 0)).polyline(points).close().revolve(360)
divertor_lower.name = "divertor_lower"
```
then this name will be assigned to the solids.
### 2. Add `Assembly.split_solids()`
**Workflow**
```
model = paramak.tokamak_from_plasma(
    radial_build = [...],
    extra_cut_shapes=extra_cut_shapes,
    extra_intersect_shapes=[divertor_lower],
)
model = model.split_solids()
```
**New behavior**

Explodes multi-solid compound parts into separate entries:
```

toroidal_field_coil
└── Compound(3 solids)
```

becomes:
```

toroidal_field_coil_1
toroidal_field_coil_2
toroidal_field_coil_3
```
**Single-solid behavior**
Single-solid parts are preserved unchanged:

`layer_1`

remains:

`layer_1`

# Test
**Model with 16 TF coils, 6 PF coils and Diverotr
output of `print(model.names())`**

`['toroidal_field_coil_1_1', 'toroidal_field_coil_1_2', 'toroidal_field_coil_1_3', 'toroidal_field_coil_1_4', 'toroidal_field_coil_1_5', 'toroidal_field_coil_1_6', 'toroidal_field_coil_1_7', 'toroidal_field_coil_1_8', 'toroidal_field_coil_1_9', 'toroidal_field_coil_1_10', 'toroidal_field_coil_1_11', 'toroidal_field_coil_1_12', 'toroidal_field_coil_1_13', 'toroidal_field_coil_1_14', 'toroidal_field_coil_1_15', 'toroidal_field_coil_1_16', 'poloidal_field_coil_2', 'poloidal_field_coil_case_3', 'poloidal_field_coil_4', 'poloidal_field_coil_case_5', 'poloidal_field_coil_6', 'poloidal_field_coil_case_7', 'poloidal_field_coil_8', 'poloidal_field_coil_case_9', 'poloidal_field_coil_10', 'poloidal_field_coil_case_11', 'poloidal_field_coil_12', 'poloidal_field_coil_case_13', 'divertor_lower_1_1', 'divertor_lower_1_2', 'layer_1', 'layer_2', 'layer_3', 'layer_4', 'layer_5', 'layer_6', 'layer_7', 'layer_8', 'layer_9', 'layer_10']`

**FreeCAD**
<img width="1920" height="1038" alt="Screenshot From 2026-05-27 17-31-30" src="https://github.com/user-attachments/assets/89f7b8bc-9cc3-4958-a64f-3aaac3414a4d" />

**Before it was**

`['add_extra_cut_shape_1', 'add_extra_cut_shape_2', 'add_extra_cut_shape_3', 'add_extra_cut_shape_4', 'add_extra_cut_shape_5', 'add_extra_cut_shape_6', 'add_extra_cut_shape_7', 'add_extra_cut_shape_8', 'add_extra_cut_shape_9', 'add_extra_cut_shape_10', 'add_extra_cut_shape_11', 'add_extra_cut_shape_12', 'add_extra_cut_shape_13', 'extra_intersect_shapes_1', 'layer_1', 'layer_2', 'layer_3', 'layer_4', 'layer_5', 'layer_6', 'layer_7', 'layer_8', 'layer_9', 'layer_10']`

**FreeCAD**
<img width="1920" height="1038" alt="Screenshot From 2026-05-27 15-50-24" src="https://github.com/user-attachments/assets/0204bad0-cec8-4e8f-ac72-d3d69e94f2f5" />

**Fixes issue #325**
**Fixes issue #327**
**Fixes discussion #377**