### PR TITLE
Add revolved_shape workplane for arbitrary revolved profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           python examples/spherical_tokamak_from_plasma_with_tf_magnets.py
           python examples/spherical_tokamak_minimal.py
           python examples/tokamak_from_plasma_with_divertor.py
+          python examples/divertor_curved.py
           python examples/tokamak_minimal.py
           python examples/tokamak_from_plasma_minimal.py
 

--- a/docs/examples_spherical_tokamak.rst
+++ b/docs/examples_spherical_tokamak.rst
@@ -112,6 +112,56 @@ Spherical tokamak with divertor
         extra_intersect_shapes=[divertor_lower]
     ).toCompound()
 
+.. _spherical_custom_divertor:
+
+Spherical tokamak with custom divertor
+--------------------------------------
+
+- The revolved_shape function builds a solid by revolving a custom 2D (R, Z, connection) profile. Here straight segments make a small V-shaped divertor plate.
+- This example adds the revolved shape directly to the reactor assembly with ``assembly.add``, rather than passing it to ``extra_intersect_shapes``. The plate therefore keeps its full shape and can sit anywhere inside the vessel, **outside the blanket envelope** — it is not clipped to the blanket.
+- For the alternative approach, where the revolved shape is intersected with the blanket so the divertor is confined to the blanket envelope, see the :ref:`tokamak_custom_divertor` example.
+
+.. cadquery::
+    :select: result
+    :width: 100%
+    :height: 600px
+
+    import cadquery as cq
+    import paramak
+
+    # small V-shaped divertor plate from straight segments, sitting in the
+    # lower cavity between the plasma and the lower blanket
+    points = [
+        (160, -312, "straight"),
+        (220, -336, "straight"),
+        (280, -312, "straight"),
+        (280, -330, "straight"),
+        (220, -354, "straight"),
+        (160, -330, "straight"),
+    ]
+    divertor = paramak.revolved_shape(points=points, rotation_angle=180, plane="XZ")
+
+    result = paramak.spherical_tokamak_from_plasma(
+        radial_build=[
+            (paramak.LayerType.GAP, 10),
+            (paramak.LayerType.SOLID, 50),
+            (paramak.LayerType.SOLID, 15),
+            (paramak.LayerType.GAP, 50),
+            (paramak.LayerType.PLASMA, 300),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.SOLID, 15),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+        ],
+        elongation=2,
+        triangularity=0.55,
+        rotation_angle=180,
+    )
+
+    # add the divertor plate directly to the assembly so it is not clipped to the blanket
+    result.add(divertor, name="divertor", color=cq.Color("red"))
+    result = result.toCompound()
+
 Spherical tokamak with poloidal field coils
 -------------------------------------------
 

--- a/docs/examples_tokamak.rst
+++ b/docs/examples_tokamak.rst
@@ -120,13 +120,14 @@ Tokamak with divertor
         extra_intersect_shapes=[divertor_lower]
     ).toCompound()
 
+.. _tokamak_custom_divertor:
+
 Tokamak with custom divertor
 ----------------------------
 
-- The revolved_shape function builds a solid by revolving a custom 2D profile, which can be used as a divertor.
-- Each point is a (R, Z, connection) tuple where connection is "straight", "spline" or "circle", so splines produce a smooth curved profile rather than a blocky rectangle.
-- The profile is closed automatically, so the first point does not need to be repeated.
-- This example adds a curved divertor to a tokamak_from_plasma reactor.
+- The revolved_shape function builds a solid by revolving a custom 2D (R, Z, connection) profile, where connection is "straight", "spline" or "circle". Splines produce a smooth curved profile rather than a blocky rectangle, and the profile is closed automatically.
+- This example passes the revolved shape to ``extra_intersect_shapes``, so it is intersected with the blanket layers. The divertor is therefore **confined to the blanket envelope** and cannot extend into the plasma cavity.
+- For the alternative approach, where a revolved shape is added directly to the assembly so it can sit outside the blanket envelope, see the :ref:`spherical_custom_divertor` example.
 
 .. cadquery::
     :select: result

--- a/docs/examples_tokamak.rst
+++ b/docs/examples_tokamak.rst
@@ -120,6 +120,53 @@ Tokamak with divertor
         extra_intersect_shapes=[divertor_lower]
     ).toCompound()
 
+Tokamak with custom divertor
+----------------------------
+
+- The revolved_shape function builds a solid by revolving a custom 2D profile, which can be used as a divertor.
+- Each point is a (R, Z, connection) tuple where connection is "straight", "spline" or "circle", so splines produce a smooth curved profile rather than a blocky rectangle.
+- The profile is closed automatically, so the first point does not need to be repeated.
+- This example adds a curved divertor to a tokamak_from_plasma reactor.
+
+.. cadquery::
+    :select: result
+    :width: 100%
+    :height: 600px
+
+    import paramak
+
+    # curved divertor profile in the XZ plane, each point is (R, Z, connection)
+    points = [
+        (300, -700, "straight"),
+        (300, -300, "spline"),
+        (370, -180, "spline"),
+        (470, -240, "spline"),
+        (560, -180, "spline"),
+        (600, -700, "straight"),
+    ]
+    divertor_lower = paramak.revolved_shape(points=points, rotation_angle=180, plane="XZ")
+
+    result = paramak.tokamak_from_plasma(
+        radial_build=[
+            (paramak.LayerType.GAP, 10),
+            (paramak.LayerType.SOLID, 30),
+            (paramak.LayerType.SOLID, 50),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.SOLID, 120),
+            (paramak.LayerType.SOLID, 20),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.PLASMA, 300),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.SOLID, 20),
+            (paramak.LayerType.SOLID, 120),
+            (paramak.LayerType.SOLID, 10),
+        ],
+        elongation=2,
+        triangularity=0.55,
+        rotation_angle=180,
+        extra_intersect_shapes=[divertor_lower]
+    ).toCompound()
+
 Tokamak with poloidal field coils
 ---------------------------------
 

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -23,5 +23,6 @@ Workplanes
 .. autofunction:: plasma_simplified
 .. autofunction:: poloidal_field_coil_case
 .. autofunction:: poloidal_field_coil
+.. autofunction:: revolved_shape
 .. autofunction:: toroidal_field_coil_rectangle
 .. autofunction:: u_shaped_dome

--- a/examples/divertor_curved.py
+++ b/examples/divertor_curved.py
@@ -1,0 +1,54 @@
+"""Builds a curved lower divertor and intersects it into a tokamak.
+
+Demonstrates building a divertor with the shape-based `extra_intersect_shapes`
+workflow plus the `paramak.revolved_shape` helper, which revolves an arbitrary
+2D profile and builds the same smooth spline/arc profiles used internally for
+the blankets and domes (instead of a blocky rectangle).
+"""
+
+import cadquery as cq
+
+import paramak
+
+# Divertor cross-section in the XZ plane. The third element of each point is
+# the connection type: "straight", "spline" or "circle". Using splines gives
+# a smooth curved profile instead of a blocky rectangle.
+# Do not repeat the first point; revolved_shape closes the profile for you.
+points = [
+    (300, -700, "straight"),
+    (300, -300, "spline"),  # inner vertical target
+    (370, -180, "spline"),  # curve toward the dome
+    (470, -240, "spline"),  # dome
+    (560, -180, "spline"),  # outer vertical target
+    (600, -700, "straight"),
+]
+
+divertor_lower = paramak.revolved_shape(points=points, rotation_angle=180, plane="XZ")
+
+# Save the divertor shape on its own.
+cq.exporters.export(divertor_lower, "divertor.step")
+print("Saved divertor.step")
+
+my_reactor = paramak.tokamak_from_plasma(
+    radial_build=[
+        (paramak.LayerType.GAP, 10),
+        (paramak.LayerType.SOLID, 30),
+        (paramak.LayerType.SOLID, 50),
+        (paramak.LayerType.SOLID, 10),
+        (paramak.LayerType.SOLID, 120),
+        (paramak.LayerType.SOLID, 20),
+        (paramak.LayerType.GAP, 60),
+        (paramak.LayerType.PLASMA, 300),
+        (paramak.LayerType.GAP, 60),
+        (paramak.LayerType.SOLID, 20),
+        (paramak.LayerType.SOLID, 120),
+        (paramak.LayerType.SOLID, 10),
+    ],
+    elongation=2,
+    triangularity=0.55,
+    rotation_angle=180,
+    extra_intersect_shapes=[divertor_lower],
+)
+
+my_reactor.save("tokamak_with_divertor.step")
+print("Saved tokamak_with_divertor.step")

--- a/src/paramak/__init__.py
+++ b/src/paramak/__init__.py
@@ -12,6 +12,7 @@ from .workplanes.dished_vacuum_vessel import dished_vacuum_vessel
 from .workplanes.plasma_simplified import plasma_simplified
 from .workplanes.poloidal_field_coil import poloidal_field_coil
 from .workplanes.poloidal_field_coil_case import poloidal_field_coil_case
+from .workplanes.revolved_shape import revolved_shape
 from .workplanes.toroidal_field_coil_rectangle import toroidal_field_coil_rectangle
 from .workplanes.u_shaped_dome import u_shaped_dome
 from .workplanes.toroidal_field_coil_princeton_d import toroidal_field_coil_princeton_d
@@ -33,6 +34,7 @@ __all__ = [
     "plasma_simplified",
     "poloidal_field_coil",
     "poloidal_field_coil_case",
+    "revolved_shape",
     "spherical_tokamak",
     "spherical_tokamak_from_plasma",
     "tokamak",

--- a/src/paramak/workplanes/revolved_shape.py
+++ b/src/paramak/workplanes/revolved_shape.py
@@ -1,0 +1,63 @@
+import typing
+
+import cadquery as cq
+
+from ..utils import create_wire_workplane_from_points
+
+
+def revolved_shape(
+    points: typing.Sequence[typing.Tuple[float, float, str]],
+    rotation_angle: float = 360.0,
+    name: str = "revolved_shape",
+    color: typing.Tuple[float, float, float, typing.Optional[float]] = (
+        0.5,
+        0.5,
+        0.5,
+    ),
+    plane: str = "XZ",
+    origin: typing.Tuple[float, float, float] = (0, 0, 0),
+    obj=None,
+) -> cq.Workplane:
+    """Creates a solid by revolving an arbitrary closed 2D profile around the axis.
+
+    The profile is described by a list of points where each point is a
+    ``(R, Z, connection)`` tuple. ``connection`` is one of ``"straight"``,
+    ``"spline"`` or ``"circle"`` and describes how that point joins to the next
+    one. This is the same profile description used internally by paramak's
+    blanket and dome components, so splines and arcs produce smooth curved
+    profiles rather than blocky polylines.
+
+    The profile is closed automatically, so the first point should not be
+    repeated at the end of the list. This is convenient for building custom
+    shapes to pass to the ``extra_intersect_shapes`` or ``extra_cut_shapes``
+    arguments of the reactor assemblies, for example a curved divertor.
+
+    Args:
+        points: the profile points as ``(R, Z, connection)`` tuples, ordered
+            around the outline. Do not repeat the first point; the profile is
+            closed automatically.
+        rotation_angle: the angle in degrees to revolve the profile around the
+            axis. Defaults to 360.
+        name: the name assigned to the resulting solid.
+        color: the RGB(A) color assigned to the resulting solid.
+        plane: the plane to build the profile on, e.g. "XZ".
+        origin: the origin of the workplane.
+        obj: an optional existing CadQuery object to build upon.
+
+    Returns:
+        A CadQuery Workplane containing the revolved solid.
+    """
+
+    if len(points) < 3:
+        msg = f"revolved_shape requires at least 3 points to form a profile, got {len(points)}."
+        raise ValueError(msg)
+
+    # close the profile by repeating the first point at the end
+    closed_points = list(points) + [points[0]]
+
+    wire = create_wire_workplane_from_points(points=closed_points, plane=plane, origin=origin, obj=obj)
+
+    solid = wire.revolve(rotation_angle)
+    solid.name = name
+    solid.color = color
+    return solid

--- a/tests/test_workplanes/test_revolved_shape.py
+++ b/tests/test_workplanes/test_revolved_shape.py
@@ -1,0 +1,50 @@
+import cadquery as cq
+import pytest
+
+import paramak
+
+
+def test_creation():
+    points = [
+        (300, -700, "straight"),
+        (300, -300, "spline"),
+        (470, -240, "spline"),
+        (600, -700, "straight"),
+    ]
+    test_shape = paramak.revolved_shape(points=points, rotation_angle=180)
+
+    assert test_shape.val().isValid()
+    assert test_shape.val().Volume() > 0
+    cq.exporters.export(test_shape, "revolved_shape.step")
+
+
+def test_rotation_angle():
+    # a rectangular profile away from the axis, so volume scales with angle
+    points = [
+        (300, -700, "straight"),
+        (300, -300, "straight"),
+        (600, -300, "straight"),
+        (600, -700, "straight"),
+    ]
+    half = paramak.revolved_shape(points=points, rotation_angle=180)
+    full = paramak.revolved_shape(points=points, rotation_angle=360)
+
+    assert full.val().Volume() == pytest.approx(2 * half.val().Volume(), rel=0.01)
+
+
+def test_name_and_color():
+    points = [
+        (300, -700, "straight"),
+        (300, -300, "straight"),
+        (600, -300, "straight"),
+        (600, -700, "straight"),
+    ]
+    test_shape = paramak.revolved_shape(points=points, name="my_divertor", color=(0.1, 0.2, 0.3))
+
+    assert test_shape.name == "my_divertor"
+    assert test_shape.color == (0.1, 0.2, 0.3)
+
+
+def test_too_few_points_raises():
+    with pytest.raises(ValueError):
+        paramak.revolved_shape(points=[(0, 0, "straight"), (1, 1, "straight")])


### PR DESCRIPTION
## What

Adds a public `paramak.revolved_shape(points, rotation_angle=...)` helper that revolves an arbitrary 2D profile into a solid.

The profile is a list of `(R, Z, connection)` points where `connection` is `"straight"`, `"spline"` or `"circle"` — the same profile description already used internally by the blanket and dome components, so curved profiles come out smooth. The profile is **closed automatically** (no need to repeat the first point).

## Why

Motivated by [discussion #381](https://github.com/fusion-energy/paramak/discussions/381): the old `divertor_ITER.py` component was removed in the rewrite, and users now build divertors as shapes passed to `extra_intersect_shapes`. Until now the only way to build a curved profile was to reach into `paramak.utils.create_wire_workplane_from_points`, manually append the first point to close the loop, then `.revolve(...)`. This wraps that boilerplate into a documented, first-class function — handy for custom `extra_intersect_shapes` / `extra_cut_shapes`, e.g. a curved divertor.

It follows the existing workplane convention exactly (build wire → revolve → set `name`/`color` → return).

## Changes

- `src/paramak/workplanes/revolved_shape.py` — new workplane function
- `src/paramak/__init__.py` — export in public API and `__all__`
- `docs/python_api.rst` — `autofunction` entry under Workplanes
- `docs/examples_tokamak.rst` — "Tokamak with custom divertor" cadquery-rendered example
- `examples/divertor_curved.py` — curved divertor example using it
- `tests/test_workplanes/test_revolved_shape.py` — unit tests for the new function
- `.github/workflows/ci.yml` — run `examples/divertor_curved.py` in the CI example list

## Testing

- new unit tests pass (creation/validity, rotation-angle scaling, name/color, too-few-points error)
- the docs example and `examples/divertor_curved.py` run and produce a valid divertor solid intersected into a tokamak (`.toCompound()` volume ~6.5e8 mm³)
- existing `tests/test_utils.py` + `tests/test_workplanes` pass