### PR TITLE
Fix dev/stable docs built with linkcheck instead of HTML

### DIFF
--- a/.github/workflows/documentation_update.yml
+++ b/.github/workflows/documentation_update.yml
@@ -45,14 +45,16 @@ jobs:
           sphinx-build docs _build/${{ github.ref_name }}
           rm -rf _build/stable
           mkdir -p _build/stable
-          sphinx-build -b linkcheck docs _build/stable
-        
+          sphinx-build docs _build/stable
+          sphinx-build -b linkcheck docs /tmp/linkcheck
+
       - name: Sphinx build dev version
         if: (github.event_name == 'push' || github.event_name == 'pull_request') && !startsWith(github.ref, 'refs/tags/')
         run: |
           rm -rf _build/dev
           mkdir -p _build/dev
-          sphinx-build -b linkcheck docs _build/dev
+          sphinx-build docs _build/dev
+          sphinx-build -b linkcheck docs /tmp/linkcheck
 
       - name: Deploy docs to GitHub Pages
         if: github.event_name == 'push' || startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Problem

The `dev` and `stable` documentation versions stopped updating as HTML back in PR #366 ("Adding url link checking to repo", Jan 2025). That PR intended to *add* link checking, but it accidentally **replaced** the HTML build with the linkcheck builder:

```yaml
sphinx-build -b linkcheck docs _build/dev
sphinx-build -b linkcheck docs _build/stable
```

The `linkcheck` builder produces **no HTML pages** — only `output.txt`/`output.json`. Combined with `keep_files: true` on the `gh-pages` deploy, the old HTML on `/dev` and `/stable` has never been overwritten, so both have shown stale content from early Jan 2025 ever since. Tagged versions (e.g. `/0.9.4`) were unaffected because that step still used the HTML builder.

## Fix

- Restore the default (HTML) builder for both the `dev` and `stable` builds.
- Run `linkcheck` as a separate step writing to `/tmp/linkcheck` (outside `publish_dir`) so it still validates links without clobbering the HTML output or publishing junk into the site.

## Follow-up (manual, after merge)

- Merging this triggers a push to `main` → rebuilds `/dev` as HTML. Verify `/dev` shows current docs.
- Because of `keep_files: true`, stale linkcheck `output.txt`/`output.json` leftovers remain on the `gh-pages` branch under `dev/` and `stable/` — delete those once for a clean state.
- `/stable` and a new `/<version>` folder only rebuild on a tag push, so a release is needed to repair `/stable`. Remember to add the new version to `docs/version_switcher.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)