### PR TITLE
Add released versions 0.9.2-0.9.10 to docs version switcher

### DIFF
--- a/docs/version_switcher.json
+++ b/docs/version_switcher.json
@@ -10,8 +10,48 @@
         "url": "https://fusion-energy.github.io/paramak/stable"
     },
     {
+        "name": "0.9.10",
+        "version": "0.9.10",
+        "url": "https://fusion-energy.github.io/paramak/0.9.10"
+    },
+    {
+        "name": "0.9.9",
+        "version": "0.9.9",
+        "url": "https://fusion-energy.github.io/paramak/0.9.9"
+    },
+    {
+        "name": "0.9.8",
+        "version": "0.9.8",
+        "url": "https://fusion-energy.github.io/paramak/0.9.8"
+    },
+    {
+        "name": "0.9.7",
+        "version": "0.9.7",
+        "url": "https://fusion-energy.github.io/paramak/0.9.7"
+    },
+    {
+        "name": "0.9.6",
+        "version": "0.9.6",
+        "url": "https://fusion-energy.github.io/paramak/0.9.6"
+    },
+    {
+        "name": "0.9.5",
+        "version": "0.9.5",
+        "url": "https://fusion-energy.github.io/paramak/0.9.5"
+    },
+    {
         "name": "0.9.4",
         "version": "0.9.4",
         "url": "https://fusion-energy.github.io/paramak/0.9.4"
+    },
+    {
+        "name": "0.9.3",
+        "version": "0.9.3",
+        "url": "https://fusion-energy.github.io/paramak/0.9.3"
+    },
+    {
+        "name": "0.9.2",
+        "version": "0.9.2",
+        "url": "https://fusion-energy.github.io/paramak/0.9.2"
     }
 ]


### PR DESCRIPTION
## Problem

The version dropdown in the hosted docs only shows `dev`, `stable`, and `0.9.4`. The switcher is driven entirely by the manually-maintained `docs/version_switcher.json`, so every other deployed version was hidden.

The `gh-pages` branch actually has these deployed: `0.9.2`, `0.9.3`, `0.9.4`, `0.9.5`, `0.9.6`, `0.9.7`, `0.9.8`, `0.9.9`, `0.9.10`.

## Change

Add all deployed versions to `version_switcher.json`, ordered newest first. Single-file change.

## Note for future releases

This file must be updated by hand on each release (add an entry pointing at `https://fusion-energy.github.io/paramak/<version>`), or the new version won't appear in the dropdown.