### PR TITLE
Clean up assembly build loops and fix example save filenames

### DIFF
--- a/examples/tokamak_with_pf_magnets.py
+++ b/examples/tokamak_with_pf_magnets.py
@@ -48,6 +48,6 @@ my_reactor = paramak.tokamak(
     extra_cut_shapes=extra_cut_shapes,
 )
 
-my_reactor.save(f"tokamak_minimal.step")
-print(f"Saved as tokamak_minimal.step")
+my_reactor.save(f"tokamak_with_pf_magnets.step")
+print(f"Saved as tokamak_with_pf_magnets.step")
 

--- a/examples/tokamak_with_pf_tf_magnets_divertor.py
+++ b/examples/tokamak_with_pf_tf_magnets_divertor.py
@@ -71,5 +71,5 @@ my_reactor = paramak.tokamak(
     extra_cut_shapes=extra_cut_shapes,
     extra_intersect_shapes=[divertor_lower],
 )
-my_reactor.save(f"tokamak_with_divertor.step")
-print(f"Saved as tokamak_with_divertor.step")
+my_reactor.save(f"tokamak_with_pf_tf_magnets_divertor.step")
+print(f"Saved as tokamak_with_pf_tf_magnets_divertor.step")

--- a/src/paramak/assemblies/spherical_tokamak.py
+++ b/src/paramak/assemblies/spherical_tokamak.py
@@ -264,21 +264,15 @@ def spherical_tokamak(
             raise ValueError(f"extra_cut_shapes should only contain cadquery Workplanes, not {type(entry)}")
 
     # builds up the intersect shapes
-    intersect_shapes_to_cut = []
     if len(extra_intersect_shapes) > 0:
-        all_shapes = []
-        for shape in inner_radial_build + blanket_layers:
-            all_shapes.append(shape)
-
         # makes a union of the the radial build to use as a base for the intersect shapes
         reactor_compound = inner_radial_build[0]
-        for i, entry in enumerate(inner_radial_build[1:] + blanket_layers):
+        for entry in inner_radial_build[1:] + blanket_layers:
             reactor_compound = reactor_compound.union(entry)
 
         # adds the extra intersect shapes to the assembly
         for i, entry in enumerate(extra_intersect_shapes):
             reactor_entry_intersection = entry.intersect(reactor_compound)
-            intersect_shapes_to_cut.append(reactor_entry_intersection)
             # Use the object's name attribute if it exists, otherwise fallback
             base_name = getattr(entry, 'name', None)
             if base_name:
@@ -287,25 +281,14 @@ def spherical_tokamak(
                 name=f"extra_intersect_shapes_{i+1}"
             my_assembly.add(reactor_entry_intersection, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
-    # builds just the core if there are no extra parts
-    if len(extra_cut_shapes) == 0 and len(intersect_shapes_to_cut) == 0:
-        for i, entry in enumerate(inner_radial_build+blanket_layers):
-            name = f"layer_{i+1}"
-            my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
-    else:
-        shapes_and_components = []
-        for i, entry in enumerate(inner_radial_build + blanket_layers):
-            for cutter in extra_cut_shapes + extra_intersect_shapes:
-                entry = entry.cut(cutter)
-                # TODO use something like this to return a list of material tags for the solids in order, as some solids get split into multiple
-                # for subentry in entry.objects:
-                #     print(i, subentry)
-            shapes_and_components.append(entry)
-
-        for i, entry in enumerate(shapes_and_components):
-            # TODO track the names of shapes, even when extra shapes are made due to splitting
-            name=f"layer_{i+1}"
-            my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
+    # adds the core layers, cutting each with any extra shapes (a no-op when there are none)
+    cutters = extra_cut_shapes + extra_intersect_shapes
+    for i, entry in enumerate(inner_radial_build + blanket_layers):
+        for cutter in cutters:
+            entry = entry.cut(cutter)
+        # TODO track the names of shapes, even when extra shapes are made due to splitting
+        name = f"layer_{i+1}"
+        my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
     my_assembly.add(plasma, name="plasma", color=cq.Color(*colors.get("plasma", (0.5,0.5,0.5))))
 

--- a/src/paramak/assemblies/tokamak.py
+++ b/src/paramak/assemblies/tokamak.py
@@ -302,21 +302,15 @@ def tokamak(
             raise ValueError(f"extra_cut_shapes should only contain cadquery Workplanes, not {type(entry)}")
 
     # builds up the intersect shapes
-    intersect_shapes_to_cut = []
     if len(extra_intersect_shapes) > 0:
-        all_shapes = []
-        for shape in inner_radial_build + blanket_layers:
-            all_shapes.append(shape)
-
         # makes a union of the the radial build to use as a base for the intersect shapes
         reactor_compound = inner_radial_build[0]
-        for i, entry in enumerate(inner_radial_build[1:] + blanket_layers):
+        for entry in inner_radial_build[1:] + blanket_layers:
             reactor_compound = reactor_compound.union(entry)
 
         # adds the extra intersect shapes to the assembly
         for i, entry in enumerate(extra_intersect_shapes):
             reactor_entry_intersection = entry.intersect(reactor_compound)
-            intersect_shapes_to_cut.append(reactor_entry_intersection)
             # Use the object's name attribute if it exists, otherwise fallback
             base_name = getattr(entry, 'name', None)
             if base_name:
@@ -325,25 +319,14 @@ def tokamak(
                 name=f"extra_intersect_shapes_{i+1}"
             my_assembly.add(reactor_entry_intersection, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
-    # builds just the core if there are no extra parts
-    if len(extra_cut_shapes) == 0 and len(intersect_shapes_to_cut) == 0:
-        for i, entry in enumerate(inner_radial_build+blanket_layers):
-            name=f"layer_{i+1}"
-            my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
-    else:
-        shapes_and_components = []
-        for i, entry in enumerate(inner_radial_build + blanket_layers):
-            for cutter in extra_cut_shapes + extra_intersect_shapes:
-                entry = entry.cut(cutter)
-                # TODO use something like this to return a list of material tags for the solids in order, as some solids get split into multiple
-                # for subentry in entry.objects:
-                #     print(i, subentry)
-            shapes_and_components.append(entry)
-
-        for i, entry in enumerate(shapes_and_components):
-            name=f"layer_{i+1}"
-            # TODO track the names of shapes, even when extra shapes are made due to splitting
-            my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
+    # adds the core layers, cutting each with any extra shapes (a no-op when there are none)
+    cutters = extra_cut_shapes + extra_intersect_shapes
+    for i, entry in enumerate(inner_radial_build + blanket_layers):
+        for cutter in cutters:
+            entry = entry.cut(cutter)
+        # TODO track the names of shapes, even when extra shapes are made due to splitting
+        name = f"layer_{i+1}"
+        my_assembly.add(entry, name=name, color=cq.Color(*colors.get(name, (0.5,0.5,0.5))))
 
     my_assembly.add(plasma, name="plasma", color=cq.Color(*colors.get("plasma", (0.5,0.5,0.5))))
 

--- a/tests/test_assemblies/test_tokamak.py
+++ b/tests/test_assemblies/test_tokamak.py
@@ -31,3 +31,46 @@ def test_colors():
             "layer_5": (0.5, 0.5, 0.8),
         }
     )
+
+
+def test_layer_names_are_contiguous_with_interior_gaps():
+    "layer names should be sequential layer_1..layer_N even when gaps sit between solid layers"
+
+    my_reactor = paramak.tokamak(
+        radial_build=[
+            (paramak.LayerType.GAP, 50),
+            (paramak.LayerType.SOLID, 50),
+            (paramak.LayerType.GAP, 10),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.GAP, 20),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.PLASMA, 300),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.GAP, 20),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+        ],
+        vertical_build=[
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.GAP, 20),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.PLASMA, 650),
+            (paramak.LayerType.GAP, 60),
+            (paramak.LayerType.SOLID, 10),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.GAP, 20),
+            (paramak.LayerType.SOLID, 60),
+            (paramak.LayerType.SOLID, 10),
+        ],
+        rotation_angle=180,
+    )
+
+    assert my_reactor.names() == ["layer_1", "layer_2", "layer_3", "layer_4", "layer_5", "plasma"]


### PR DESCRIPTION
## Summary

Small, self-contained cleanup extracted while reviewing #392, independent of any layer-naming design decision:

- **Simplify the assembly build loops** in `tokamak()` and `spherical_tokamak()`. The "core only" and "with extra shapes" branches were near-duplicates, so they're merged into a single loop that cuts each core layer by `extra_cut_shapes + extra_intersect_shapes` (a no-op when there are none). Also drops the unused `all_shapes` and `intersect_shapes_to_cut` locals.
- **Fix example save filenames**: `tokamak_with_pf_magnets.py` was saving as `tokamak_minimal.step`, and `tokamak_with_pf_tf_magnets_divertor.py` as `tokamak_with_divertor.step`.
- **Add a regression test** asserting layer names stay contiguous (`layer_1 … layer_N`) even when gaps sit between solid layers.

## Verification

- **Behaviour-preserving:** `names()` and per-part solid counts are identical before/after across all build paths (core-only, extra_cut, extra_intersect, both; tokamak + spherical).
- `pytest tests/test_assemblies tests/test_utils` → 36 passed, 3 skipped.
